### PR TITLE
feat(auth): implement dual-auth model with OAuth 2.0 support

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -88,7 +88,7 @@ Requirements:
 
 Requirements:
 
-- OAuth 2.0 / OIDC integration for authentication
+- OAuth 2.0 integration for authentication
 - Two roles enforced: `admin` (full access), `admin-readonly` (read-only access)
 - Role assignment based on OAuth group membership claims
 - All model management APIs (load/unload) require `admin` role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Role-Based Access Control (RBAC)
+
+- Implemented RBAC with two roles: `admin` (full access) and `admin-readonly` (read-only)
+- Backend route-level authorization via `fastify.requireRole()` hooks on all API routes
+- OAuth group mapping: `sardeenz-admins` → `admin`, `sardeenz-admins-readonly` → `admin-readonly`
+- Users with no matching groups receive 403 with message to contact administrator
+- HuggingFace token masking for read-only users (sees masked placeholder instead of real token)
+- Frontend `AuthContext` enhanced with `canWrite` helper for conditional UI rendering
+- User dropdown displays role label (e.g., "admin" or "admin-readonly")
+- Write action buttons disabled with tooltips for read-only users across all components:
+  - Load/Unload models, Save/Load/Delete configurations
+  - Start/Delete benchmarks, Delete memory profiles
+  - Modify settings (HF token)
+
 ### Model Configuration Management
 
 - Added persistent model configuration storage with SQLite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **sardeenz** is a multi-model management platform that enables dynamic loading, management, and serving of multiple Large Language Models (LLMs) through a unified interface. Built on top of vLLM (inference engine) and KVCached (GPU memory sharing), it allows efficient multi-model hosting on a single GPU.
 
 **Core Components:**
+
 - **Controller API**: Dynamically load/unload models, query status, manage GPU memory (Fastify + TypeScript)
   - Real-time model load progress via SSE events
   - Intelligent error extraction from vLLM logs
@@ -17,6 +18,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Unified Proxy**: Single endpoint for all inference requests with OpenAI-compatible API (<50ms routing overhead target)
 - **Admin Dashboard**: React + PatternFly 6 web interface for model management, monitoring, and benchmarking
 - **Container Deployment**: Unified single-process container (Fastify serves API + frontend) for OpenShift/Kubernetes
+- **Authentication**: Dual-auth model separating admin (JWT) from inference (optional API key)
+  - Admin: Three modes (`none`, `simple`, `oauth`) via `AUTH_MODE` for dashboard/controller API
+  - Inference: Optional `INFERENCE_API_KEY` for OpenAI-compatible endpoints (`/v1/*`)
 
 **Documentation:** See [`docs/`](./docs/) for detailed architecture, API guides, and deployment instructions.
 
@@ -41,6 +45,7 @@ npm run dev
 ## Architecture
 
 This project uses an npm workspace monorepo structure:
+
 - `apps/backend` - Fastify backend (Controller API + Proxy)
 - `apps/frontend` - React + PatternFly dashboard
 - `packages/types` - Shared TypeScript types
@@ -48,6 +53,7 @@ This project uses an npm workspace monorepo structure:
 - `packages/utils` - Shared utilities
 
 **Key Design Decisions:**
+
 - Direct vLLM subprocess management (no Docker-in-Docker) for zero-downtime model loading
 - Hybrid storage: in-memory for runtime state, SQLite for benchmarks/profiles persistence
 - OpenAI-compatible API via vLLM native format

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -3,12 +3,37 @@ PORT=3000
 HOST=0.0.0.0
 NODE_ENV=development
 
-# OAuth/OIDC configuration (optional for development)
+# Authentication configuration
+# AUTH_MODE: 'none' (no auth), 'simple' (username/password), 'oauth' (OAuth 2.0)
+AUTH_MODE=none
+
+# Simple auth credentials (required when AUTH_MODE=simple)
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=
+
+# OAuth configuration (required when AUTH_MODE=oauth)
 OAUTH_CLIENT_ID=sardeenz
 OAUTH_CLIENT_SECRET=change-me-in-production
-OIDC_ISSUER_URL=
+OAUTH_ISSUER_URL=
+K8S_API_URL=
+
+# JWT configuration
 JWT_SECRET=change-me-in-production
+JWT_EXPIRATION_HOURS=8
+
+# API base URL (for OAuth callbacks)
 API_BASE_URL=http://localhost:3000
+
+# Frontend URL for OAuth redirects in dev (defaults to API_BASE_URL)
+# Set to http://localhost:5173 for development with Vite
+FRONTEND_URL=http://localhost:5173
+
+# Inference API key (optional)
+# When set, inference endpoints (/v1/*, /api/direct/*) require this key
+# via Authorization: Bearer <key> header (OpenAI API compatible)
+# Admin JWT auth is NOT required for inference when this is set
+# Leave empty to allow unauthenticated access to inference endpoints
+INFERENCE_API_KEY=
 
 # vLLM configuration
 VLLM_BASE_PORT=12346

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -12,38 +12,40 @@ Fastify backend providing Controller API and Unified Proxy for multi-model LLM m
 
 ## API Routes
 
-| Route File | Purpose |
-|------------|---------|
-| `src/routes/models.ts` | Model CRUD: load, unload, list, get, health check, logs |
-| `src/routes/model-configurations.ts` | Configuration CRUD: save, load, list, delete model presets |
-| `src/routes/events.ts` | SSE event streaming endpoint |
-| `src/routes/health.ts` | Backend health checks (`/api/health`, `/api/health/ready`, `/api/health/live`) |
-| `src/routes/proxy.ts` | OpenAI-compatible inference proxy (`/v1/*`) with round-robin load balancing |
-| `src/routes/direct-proxy.ts` | Port-based direct proxy (`/api/direct/:port/*`) - bypasses model routing |
-| `src/routes/gpu.ts` | GPU info and availability (`/api/gpu/info`, `/api/gpu/available`) |
-| `src/routes/memory.ts` | GPU memory info (`/api/memory/usage`, `/api/memory/usage/multi-gpu`) |
-| `src/routes/memory-profiles.ts` | Memory profile CRUD, lookup, pre-load checks |
-| `src/routes/benchmarks.ts` | Benchmark run CRUD, SSE progress, results |
-| `src/routes/orphans.ts` | Orphan process detection |
-| `src/routes/settings.ts` | Application settings (HF token) |
+| Route File                           | Purpose                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------ |
+| `src/routes/models.ts`               | Model CRUD: load, unload, list, get, health check, logs                        |
+| `src/routes/model-configurations.ts` | Configuration CRUD: save, load, list, delete model presets                     |
+| `src/routes/events.ts`               | SSE event streaming endpoint                                                   |
+| `src/routes/health.ts`               | Backend health checks (`/api/health`, `/api/health/ready`, `/api/health/live`) |
+| `src/routes/proxy.ts`                | OpenAI-compatible inference proxy (`/v1/*`) with round-robin load balancing    |
+| `src/routes/direct-proxy.ts`         | Port-based direct proxy (`/api/direct/:port/*`) - bypasses model routing       |
+| `src/routes/gpu.ts`                  | GPU info and availability (`/api/gpu/info`, `/api/gpu/available`)              |
+| `src/routes/memory.ts`               | GPU memory info (`/api/memory/usage`, `/api/memory/usage/multi-gpu`)           |
+| `src/routes/memory-profiles.ts`      | Memory profile CRUD, lookup, pre-load checks                                   |
+| `src/routes/benchmarks.ts`           | Benchmark run CRUD, SSE progress, results                                      |
+| `src/routes/orphans.ts`              | Orphan process detection                                                       |
+| `src/routes/settings.ts`             | Application settings (HF token)                                                |
+| `src/routes/auth.ts`                 | Authentication endpoints: info, login, callback, logout, me                    |
+| `src/plugins/inference-auth.ts`      | Inference API key auth (separate from admin JWT)                               |
 
 ## Stores
 
 ### In-Memory Stores
 
-| Store | Purpose |
-|-------|---------|
-| `src/stores/model-store.ts` | ModelInstance tracking by ID/path |
-| `src/stores/operation-store.ts` | ControllerOperation audit trail |
-| `src/stores/runtime-settings.ts` | Runtime settings (HF token) |
+| Store                            | Purpose                           |
+| -------------------------------- | --------------------------------- |
+| `src/stores/model-store.ts`      | ModelInstance tracking by ID/path |
+| `src/stores/operation-store.ts`  | ControllerOperation audit trail   |
+| `src/stores/runtime-settings.ts` | Runtime settings (HF token)       |
 
 ### SQLite-Backed Stores
 
-| Store | Purpose |
-|-------|---------|
-| `src/stores/benchmark-store.ts` | BenchmarkRun, Scenario, Results, Metrics persistence |
-| `src/stores/memory-profile-store.ts` | MemoryProfile storage and lookup |
-| `src/stores/model-configuration-store.ts` | SavedModelConfiguration persistence |
+| Store                                     | Purpose                                              |
+| ----------------------------------------- | ---------------------------------------------------- |
+| `src/stores/benchmark-store.ts`           | BenchmarkRun, Scenario, Results, Metrics persistence |
+| `src/stores/memory-profile-store.ts`      | MemoryProfile storage and lookup                     |
+| `src/stores/model-configuration-store.ts` | SavedModelConfiguration persistence                  |
 
 ## Development Commands
 
@@ -67,17 +69,28 @@ npm run type-check -w apps/backend  # TypeScript type check
 
 See `apps/backend/.env.example` for a complete reference.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | 3000 | Backend server port |
-| `VLLM_BASE_PORT` | 5001 | Base port for vLLM instances |
-| `VLLM_STARTUP_TIMEOUT` | 1800000 | Model startup timeout in ms (30 min default) |
-| `ENABLE_KVCACHED` | true | Enable KVCached GPU sharing |
-| `KVCACHED_AUTOPATCH` | 1 | Auto-patch vLLM for KVCached |
-| `LOG_LEVEL` | info | Pino log level |
-| `LOG_ALL_REQUESTS` | false | Force all routes to log at info level (debugging) |
-| `HF_TOKEN` | (none) | HuggingFace token for gated models |
-| `DB_PATH` | `./data/sardeenz.db` | SQLite database file path |
+| Variable               | Default                   | Description                                                                                  |
+| ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------- |
+| `PORT`                 | 3000                      | Backend server port                                                                          |
+| `VLLM_BASE_PORT`       | 5001                      | Base port for vLLM instances                                                                 |
+| `VLLM_STARTUP_TIMEOUT` | 1800000                   | Model startup timeout in ms (30 min default)                                                 |
+| `ENABLE_KVCACHED`      | true                      | Enable KVCached GPU sharing                                                                  |
+| `KVCACHED_AUTOPATCH`   | 1                         | Auto-patch vLLM for KVCached                                                                 |
+| `LOG_LEVEL`            | info                      | Pino log level                                                                               |
+| `LOG_ALL_REQUESTS`     | false                     | Force all routes to log at info level (debugging)                                            |
+| `HF_TOKEN`             | (none)                    | HuggingFace token for gated models                                                           |
+| `DB_PATH`              | `./data/sardeenz.db`      | SQLite database file path                                                                    |
+| `AUTH_MODE`            | `none`                    | Auth mode: `none`, `simple`, `oauth`                                                         |
+| `ADMIN_USERNAME`       | `admin`                   | Username for simple auth mode                                                                |
+| `ADMIN_PASSWORD`       | (none)                    | Password for simple auth (required when AUTH_MODE=simple)                                    |
+| `JWT_SECRET`           | `change-me-in-production` | Secret for JWT signing                                                                       |
+| `JWT_EXPIRATION_HOURS` | `8`                       | Token expiration in hours                                                                    |
+| `API_BASE_URL`         | `http://localhost:3000`   | Base URL for OAuth callbacks                                                                 |
+| `OAUTH_ISSUER_URL`     | (none)                    | OAuth provider URL (required when AUTH_MODE=oauth)                                           |
+| `K8S_API_URL`          | (none)                    | Kubernetes API URL for user info (required when AUTH_MODE=oauth)                             |
+| `OAUTH_CLIENT_ID`      | `sardeenz`                | OAuth2 client ID                                                                             |
+| `OAUTH_CLIENT_SECRET`  | (none)                    | OAuth2 client secret (required when AUTH_MODE=oauth)                                         |
+| `INFERENCE_API_KEY`    | (none)                    | API key for inference endpoints. When set, `/v1/*` and `/api/direct/*` require Bearer token. |
 
 ## Testing Notes
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@sardeenz/backend",
-  "version": "0.1.0",
   "description": "Backend server for Sardeenz",
   "private": true,
   "type": "module",

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -3,18 +3,31 @@ import { config as dotenvConfig } from 'dotenv'
 // Load environment variables
 dotenvConfig()
 
+import type { AuthMode } from '@sardeenz/types'
+
 export interface Config {
   // Server configuration
   port: number
   host: string
   nodeEnv: string
 
-  // OAuth/OIDC configuration
+  // Authentication configuration
+  authMode: AuthMode
+  adminUsername: string
+  adminPassword: string
+  jwtSecret: string
+  jwtExpirationHours: number
+  apiBaseUrl: string
+  frontendUrl: string
+
+  // OAuth configuration (used when authMode is 'oauth')
   oauthClientId: string
   oauthClientSecret: string
-  oidcIssuerUrl: string
-  jwtSecret: string
-  apiBaseUrl: string
+  oauthIssuerUrl: string
+  k8sApiUrl: string
+
+  // Inference API key (optional, for protecting inference endpoints separately)
+  inferenceApiKey: string
 
   // vLLM configuration
   vllmBasePort: number
@@ -70,18 +83,42 @@ function getEnvBool(key: string, defaultValue: boolean): boolean {
   return value === 'true' || value === '1'
 }
 
+function getAuthMode(): AuthMode {
+  const mode = getEnv('AUTH_MODE', 'none')
+  if (mode !== 'none' && mode !== 'simple' && mode !== 'oauth') {
+    throw new Error(`Invalid AUTH_MODE: ${mode}. Must be 'none', 'simple', or 'oauth'`)
+  }
+  return mode
+}
+
 export const config: Config = {
   // Server configuration
   port: getEnvInt('PORT', 3000),
   host: getEnv('HOST', '0.0.0.0'),
   nodeEnv: getEnv('NODE_ENV', 'development'),
 
-  // OAuth/OIDC configuration (optional for development)
-  oauthClientId: getEnv('OAUTH_CLIENT_ID', 'sardeenz'),
-  oauthClientSecret: getEnv('OAUTH_CLIENT_SECRET', 'change-me-in-production'),
-  oidcIssuerUrl: getEnv('OIDC_ISSUER_URL', ''),
+  // Authentication configuration
+  authMode: getAuthMode(),
+  adminUsername: getEnv('ADMIN_USERNAME', 'admin'),
+  adminPassword: getEnv('ADMIN_PASSWORD', ''),
   jwtSecret: getEnv('JWT_SECRET', 'change-me-in-production'),
+  jwtExpirationHours: getEnvInt('JWT_EXPIRATION_HOURS', 8),
   apiBaseUrl: getEnv('API_BASE_URL', 'http://localhost:3000'),
+  frontendUrl: getEnv(
+    'FRONTEND_URL',
+    getEnv('NODE_ENV', 'development') === 'development'
+      ? 'http://localhost:5173'
+      : getEnv('API_BASE_URL', 'http://localhost:3000')
+  ),
+
+  // OAuth configuration (used when authMode is 'oauth')
+  oauthClientId: getEnv('OAUTH_CLIENT_ID', 'sardeenz'),
+  oauthClientSecret: getEnv('OAUTH_CLIENT_SECRET', ''),
+  oauthIssuerUrl: getEnv('OAUTH_ISSUER_URL', ''),
+  k8sApiUrl: getEnv('K8S_API_URL', ''),
+
+  // Inference API key (optional, for protecting inference endpoints separately)
+  inferenceApiKey: getEnv('INFERENCE_API_KEY', ''),
 
   // vLLM configuration
   vllmBasePort: getEnvInt('VLLM_BASE_PORT', 12346),
@@ -102,3 +139,30 @@ export const config: Config = {
   // Streaming debug
   debugStreaming: getEnvBool('DEBUG_STREAMING', false),
 }
+
+// Validate auth configuration
+function validateAuthConfig(): void {
+  if (config.authMode === 'simple') {
+    if (!config.adminPassword) {
+      throw new Error('ADMIN_PASSWORD is required when AUTH_MODE is "simple"')
+    }
+  }
+
+  if (config.authMode === 'oauth') {
+    if (!config.oauthIssuerUrl) {
+      throw new Error('OAUTH_ISSUER_URL is required when AUTH_MODE is "oauth"')
+    }
+    if (!config.oauthClientSecret) {
+      throw new Error('OAUTH_CLIENT_SECRET is required when AUTH_MODE is "oauth"')
+    }
+    if (!config.k8sApiUrl) {
+      throw new Error('K8S_API_URL is required when AUTH_MODE is "oauth"')
+    }
+  }
+
+  if (config.authMode !== 'none' && config.jwtSecret === 'change-me-in-production') {
+    console.warn('WARNING: Using default JWT_SECRET. This is insecure for production environments.')
+  }
+}
+
+validateAuthConfig()

--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -1,21 +1,21 @@
 import fp from 'fastify-plugin'
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import fastifyJwt from '@fastify/jwt'
-import fastifyOAuth2 from '@fastify/oauth2'
 import { config } from '../config.js'
+import type { JWTPayload } from '@sardeenz/types'
 
-interface JWTPayload {
+// JWT sign payload (without iat/exp which are added by the library)
+export interface JWTSignPayload {
   sub: string
-  preferred_username?: string
+  username: string
   email?: string
-  realm_access?: {
-    roles: string[]
-  }
+  roles: string[]
+  authMode: 'simple' | 'oauth'
 }
 
 declare module '@fastify/jwt' {
   interface FastifyJWT {
-    payload: JWTPayload
+    payload: JWTSignPayload
     user: JWTPayload
   }
 }
@@ -23,62 +23,101 @@ declare module '@fastify/jwt' {
 declare module 'fastify' {
   interface FastifyInstance {
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>
-    requireRole: (role: 'admin' | 'admin-readonly') => (
-      request: FastifyRequest,
-      reply: FastifyReply
-    ) => Promise<void>
+    optionalAuthenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+    requireRole: (
+      role: 'admin' | 'admin-readonly'
+    ) => (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+    isPublicRoute: (url: string) => boolean
   }
 }
 
-async function authPlugin(fastify: FastifyInstance) {
-  // Register JWT plugin
-  await fastify.register(fastifyJwt, {
-    secret: config.jwtSecret,
-    decode: { complete: true },
-  })
+// Public route prefixes that don't require authentication
+const PUBLIC_ROUTE_PREFIXES = ['/api/health', '/api/auth', '/docs', '/metrics']
 
-  // Register OAuth2 plugin (if OIDC is configured)
-  if (config.oidcIssuerUrl) {
-    await fastify.register(fastifyOAuth2, {
-      name: 'oidcAuth',
-      scope: ['openid', 'profile', 'email'],
-      credentials: {
-        client: {
-          id: config.oauthClientId,
-          secret: config.oauthClientSecret,
-        },
-      },
-      startRedirectPath: '/auth/login',
-      callbackUri: `${config.apiBaseUrl}/auth/callback`,
-      discovery: {
-        issuer: config.oidcIssuerUrl,
+async function authPlugin(fastify: FastifyInstance) {
+  // Register JWT plugin (always, for all auth modes that need it)
+  if (config.authMode !== 'none') {
+    await fastify.register(fastifyJwt, {
+      secret: config.jwtSecret,
+      sign: {
+        expiresIn: `${config.jwtExpirationHours}h`,
       },
     })
   }
 
-  // Authentication decorator
-  fastify.decorate('authenticate', async function (
-    request: FastifyRequest,
-    reply: FastifyReply
-  ) {
-    try {
-      await request.jwtVerify()
-    } catch {
-      reply.code(401).send({
-        error: {
-          message: 'Unauthorized',
-          type: 'authentication_error',
-        },
-      })
-    }
+  // Helper to check if a route is public
+  fastify.decorate('isPublicRoute', (url: string): boolean => {
+    // Remove query string for comparison
+    const path = url.split('?')[0]
+    return PUBLIC_ROUTE_PREFIXES.some((prefix) => path.startsWith(prefix))
   })
 
-  // Authorization decorator
+  // Authentication decorator - enforces authentication
+  fastify.decorate(
+    'authenticate',
+    async function (request: FastifyRequest, reply: FastifyReply) {
+      // Skip authentication if auth mode is 'none'
+      if (config.authMode === 'none') {
+        return
+      }
+
+      try {
+        await request.jwtVerify()
+      } catch {
+        reply.code(401).send({
+          error: {
+            message: 'Unauthorized',
+            type: 'authentication_error',
+          },
+        })
+      }
+    }
+  )
+
+  // Optional authentication - doesn't fail if no token, but sets user if present
+  fastify.decorate(
+    'optionalAuthenticate',
+    async function (request: FastifyRequest, _reply: FastifyReply) {
+      if (config.authMode === 'none') {
+        return
+      }
+
+      try {
+        await request.jwtVerify()
+      } catch {
+        // Token invalid or missing - continue without user
+      }
+    }
+  )
+
+  // Authorization decorator - checks roles after authentication
   fastify.decorate('requireRole', function (role: 'admin' | 'admin-readonly') {
     return async (request: FastifyRequest, reply: FastifyReply) => {
+      // First authenticate
       await fastify.authenticate(request, reply)
 
-      const userRoles = request.user?.realm_access?.roles || []
+      // Skip role check if auth is disabled
+      if (config.authMode === 'none') {
+        return
+      }
+
+      const userRoles = request.user?.roles || []
+
+      // Check if user has no recognized roles at all
+      const hasNoRoles =
+        !userRoles.includes('admin') && !userRoles.includes('admin-readonly')
+
+      if (hasNoRoles) {
+        reply.code(403).send({
+          error: {
+            message:
+              'Access denied: You are not a member of any authorized groups. Please contact your administrator to be added to sardeenz-admins or sardeenz-admins-readonly.',
+            type: 'authorization_error',
+            code: 'no_roles',
+          },
+        })
+        return
+      }
 
       // 'admin' role has access to everything
       // 'admin-readonly' can only access if specifically required

--- a/apps/backend/src/plugins/inference-auth.ts
+++ b/apps/backend/src/plugins/inference-auth.ts
@@ -1,0 +1,91 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
+import { config } from '../config.js'
+
+// Route prefixes that are considered inference endpoints
+// These are excluded from admin JWT auth and use optional API key auth instead
+const INFERENCE_ROUTE_PREFIXES = [
+  '/v1/', // OpenAI-compatible endpoints
+  '/tokenize',
+  '/detokenize',
+  '/pooling',
+  '/classification',
+  '/score',
+  '/re-rank',
+  '/api/direct/', // Direct port-based proxy
+]
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    isInferenceRoute: (url: string) => boolean
+    authenticateInference: (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+  }
+}
+
+async function inferenceAuthPlugin(fastify: FastifyInstance) {
+  // Helper to check if a route is an inference route
+  fastify.decorate('isInferenceRoute', (url: string): boolean => {
+    // Remove query string for comparison
+    const path = url.split('?')[0]
+    return INFERENCE_ROUTE_PREFIXES.some((prefix) => path.startsWith(prefix))
+  })
+
+  // Inference authentication decorator
+  // If INFERENCE_API_KEY is set, validates Bearer token against it
+  // If not set, allows all requests (inference endpoints are open)
+  fastify.decorate(
+    'authenticateInference',
+    async function (request: FastifyRequest, reply: FastifyReply) {
+      // If no inference API key is configured, allow all requests
+      if (!config.inferenceApiKey) {
+        return
+      }
+
+      // Extract Bearer token from Authorization header
+      const authHeader = request.headers.authorization
+      if (!authHeader) {
+        reply.code(401).send({
+          error: {
+            message: 'API key required. Provide Authorization: Bearer <api-key> header.',
+            type: 'authentication_error',
+            code: 'missing_api_key',
+          },
+        })
+        return
+      }
+
+      // Validate Bearer token format
+      const parts = authHeader.split(' ')
+      if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') {
+        reply.code(401).send({
+          error: {
+            message: 'Invalid Authorization header format. Use: Bearer <api-key>',
+            type: 'authentication_error',
+            code: 'invalid_auth_format',
+          },
+        })
+        return
+      }
+
+      const token = parts[1]
+
+      // Validate token against configured API key
+      if (token !== config.inferenceApiKey) {
+        reply.code(401).send({
+          error: {
+            message: 'Invalid API key',
+            type: 'authentication_error',
+            code: 'invalid_api_key',
+          },
+        })
+        return
+      }
+
+      // Token is valid, continue
+    }
+  )
+}
+
+export default fp(inferenceAuthPlugin, {
+  name: 'inference-auth-plugin',
+})

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,0 +1,496 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
+import { Type, type Static } from '@sinclair/typebox'
+import { randomBytes } from 'crypto'
+import { config } from '../config.js'
+import type {
+  AuthInfoResponse,
+  LoginResponse,
+  CurrentUserResponse,
+  LogoutResponse,
+} from '@sardeenz/types'
+import type { JWTSignPayload } from '../plugins/auth.js'
+
+// Request body schema for login
+const LoginRequestSchema = Type.Object({
+  username: Type.String({ minLength: 1 }),
+  password: Type.String({ minLength: 1 }),
+})
+
+// Response schemas
+const AuthInfoResponseSchema = Type.Object({
+  mode: Type.Union([Type.Literal('none'), Type.Literal('simple'), Type.Literal('oauth')]),
+  oauthLoginUrl: Type.Optional(Type.String()),
+})
+
+const LoginResponseSchema = Type.Object({
+  token: Type.String(),
+  user: Type.Object({
+    username: Type.String(),
+    email: Type.Optional(Type.String()),
+    roles: Type.Array(Type.String()),
+  }),
+  expiresIn: Type.Number(),
+})
+
+const CurrentUserResponseSchema = Type.Object({
+  username: Type.String(),
+  email: Type.Optional(Type.String()),
+  roles: Type.Array(Type.String()),
+  authMode: Type.Union([Type.Literal('simple'), Type.Literal('oauth')]),
+  inferenceApiKey: Type.Optional(Type.String()),
+})
+
+const LogoutResponseSchema = Type.Object({
+  status: Type.Literal('success'),
+})
+
+const ErrorResponseSchema = Type.Object({
+  error: Type.Object({
+    message: Type.String(),
+    type: Type.String(),
+    code: Type.Optional(Type.String()),
+  }),
+})
+
+// In-memory state storage for OAuth CSRF protection
+// Maps state -> { callbackUrl, createdAt }
+const oauthStateStore = new Map<string, { callbackUrl: string; createdAt: number }>()
+const STATE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
+// Clean up expired states periodically
+function cleanupExpiredStates(): void {
+  const now = Date.now()
+  for (const [state, data] of oauthStateStore.entries()) {
+    if (now - data.createdAt > STATE_TTL_MS) {
+      oauthStateStore.delete(state)
+    }
+  }
+}
+
+// Run cleanup every minute
+setInterval(cleanupExpiredStates, 60 * 1000)
+
+/**
+ * Map OpenShift groups to application roles
+ */
+function mapGroupsToRoles(groups: string[]): string[] {
+  const roles: string[] = []
+  if (groups.includes('sardeenz-admins')) {
+    roles.push('admin')
+  }
+  if (groups.includes('sardeenz-admins-readonly')) {
+    roles.push('admin-readonly')
+  }
+  return roles
+}
+
+/**
+ * OpenShift user info response structure
+ */
+interface OpenShiftUserInfo {
+  kind: string
+  apiVersion: string
+  metadata: {
+    name: string
+    uid: string
+  }
+  groups: string[]
+}
+
+export default async function authRoutes(fastify: FastifyInstance) {
+  /**
+   * GET /api/auth/info
+   * Returns authentication configuration for the frontend
+   */
+  fastify.get<{ Reply: AuthInfoResponse }>(
+    '/api/auth/info',
+    {
+      schema: {
+        tags: ['auth'],
+        description: 'Get authentication configuration',
+        response: {
+          200: AuthInfoResponseSchema,
+        },
+      },
+    },
+    async (): Promise<AuthInfoResponse> => {
+      const response: AuthInfoResponse = {
+        mode: config.authMode,
+      }
+
+      // Include OAuth login URL if in OAuth mode
+      if (config.authMode === 'oauth') {
+        response.oauthLoginUrl = `${config.apiBaseUrl}/api/auth/login`
+      }
+
+      return response
+    }
+  )
+
+  /**
+   * GET /api/auth/login
+   * OAuth mode: Redirect to OAuth provider
+   */
+  fastify.get(
+    '/api/auth/login',
+    {
+      schema: {
+        tags: ['auth'],
+        description: 'Redirect to OAuth provider (OAuth mode only)',
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      if (config.authMode !== 'oauth') {
+        return reply.code(400).send({
+          error: {
+            message: 'OAuth login is not configured. Use POST /api/auth/login for simple mode.',
+            type: 'invalid_request',
+          },
+        })
+      }
+
+      // Generate state for CSRF protection
+      const state = randomBytes(32).toString('hex')
+
+      // Determine callback URL based on request origin
+      const origin =
+        request.headers.origin ||
+        (request.headers.host ? `${request.protocol}://${request.headers.host}` : null)
+      const callbackUrl = origin
+        ? `${origin}/api/auth/callback`
+        : `${config.apiBaseUrl}/api/auth/callback`
+
+      // Store state for validation
+      oauthStateStore.set(state, { callbackUrl, createdAt: Date.now() })
+
+      // Build authorization URL
+      const params = new URLSearchParams({
+        response_type: 'code',
+        client_id: config.oauthClientId,
+        redirect_uri: callbackUrl,
+        scope: 'user:info',
+        state,
+      })
+
+      const authorizationUrl = `${config.oauthIssuerUrl}/oauth/authorize?${params.toString()}`
+
+      fastify.log.debug({ authorizationUrl, callbackUrl }, 'Redirecting to OAuth provider')
+
+      return reply.redirect(authorizationUrl)
+    }
+  )
+
+  /**
+   * POST /api/auth/login
+   * Simple mode: Authenticate with username/password
+   */
+  fastify.post<{
+    Body: Static<typeof LoginRequestSchema>
+    Reply: LoginResponse | { error: { message: string; type: string } }
+  }>(
+    '/api/auth/login',
+    {
+      schema: {
+        tags: ['auth'],
+        description: 'Authenticate with username and password (simple mode only)',
+        body: LoginRequestSchema,
+        response: {
+          200: LoginResponseSchema,
+          401: ErrorResponseSchema,
+          400: ErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply): Promise<LoginResponse> => {
+      // Only allow simple auth login via this endpoint
+      if (config.authMode !== 'simple') {
+        reply.code(400).send({
+          error: {
+            message:
+              config.authMode === 'none'
+                ? 'Authentication is disabled'
+                : 'Use OAuth login for this server (GET /api/auth/login)',
+            type: 'invalid_request',
+          },
+        })
+        return reply
+      }
+
+      const { username, password } = request.body
+
+      // Validate credentials against environment variables
+      if (username !== config.adminUsername || password !== config.adminPassword) {
+        reply.code(401).send({
+          error: {
+            message: 'Invalid username or password',
+            type: 'authentication_error',
+          },
+        })
+        return reply
+      }
+
+      // Create JWT payload
+      const payload: JWTSignPayload = {
+        sub: username,
+        username,
+        roles: ['admin'], // Simple mode users get admin role
+        authMode: 'simple',
+      }
+
+      // Sign JWT
+      const token = fastify.jwt.sign(payload)
+      const expiresIn = config.jwtExpirationHours * 60 * 60 // Convert to seconds
+
+      return {
+        token,
+        user: {
+          username,
+          roles: ['admin'],
+        },
+        expiresIn,
+      }
+    }
+  )
+
+  /**
+   * GET /api/auth/callback
+   * OAuth callback handler - exchanges code for token and redirects to frontend
+   */
+  fastify.get(
+    '/api/auth/callback',
+    {
+      schema: {
+        tags: ['auth'],
+        description: 'OAuth callback endpoint',
+        querystring: Type.Object({
+          code: Type.Optional(Type.String()),
+          state: Type.Optional(Type.String()),
+          error: Type.Optional(Type.String()),
+          error_description: Type.Optional(Type.String()),
+        }),
+      },
+    },
+    async (
+      request: FastifyRequest<{
+        Querystring: {
+          code?: string
+          state?: string
+          error?: string
+          error_description?: string
+        }
+      }>,
+      reply: FastifyReply
+    ) => {
+      // Check if OAuth is configured
+      if (config.authMode !== 'oauth') {
+        return reply.code(400).send({
+          error: {
+            message: 'OAuth authentication is not configured',
+            type: 'configuration_error',
+          },
+        })
+      }
+
+      // Check for errors from OAuth provider
+      if (request.query.error) {
+        const errorMessage = request.query.error_description || request.query.error
+        fastify.log.error({ error: request.query.error, description: request.query.error_description }, 'OAuth provider returned error')
+        return reply.redirect(`${config.frontendUrl}/?auth_error=${encodeURIComponent(errorMessage)}`)
+      }
+
+      const { code, state } = request.query
+
+      if (!code || !state) {
+        return reply.redirect(`${config.frontendUrl}/?auth_error=${encodeURIComponent('Missing authorization code or state')}`)
+      }
+
+      // Validate state (CSRF protection)
+      const storedState = oauthStateStore.get(state)
+      if (!storedState) {
+        fastify.log.warn({ state }, 'Invalid or expired OAuth state')
+        return reply.redirect(`${config.frontendUrl}/?auth_error=${encodeURIComponent('Invalid or expired state. Please try logging in again.')}`)
+      }
+
+      // Remove used state
+      oauthStateStore.delete(state)
+
+      const callbackUrl = storedState.callbackUrl
+
+      try {
+        // Exchange authorization code for access token
+        const tokenUrl = `${config.oauthIssuerUrl}/oauth/token`
+
+        fastify.log.debug({ tokenUrl, callbackUrl }, 'Exchanging code for token')
+
+        const tokenResponse = await fetch(tokenUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
+          },
+          body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            client_id: config.oauthClientId,
+            client_secret: config.oauthClientSecret,
+            redirect_uri: callbackUrl,
+          }),
+        })
+
+        if (!tokenResponse.ok) {
+          const errorText = await tokenResponse.text()
+          fastify.log.error(
+            { status: tokenResponse.status, body: errorText },
+            'Token exchange failed'
+          )
+          throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+        }
+
+        const tokenData = (await tokenResponse.json()) as { access_token: string }
+        const accessToken = tokenData.access_token
+
+        // Fetch user info from Kubernetes API
+        const userInfoUrl = `${config.k8sApiUrl}/apis/user.openshift.io/v1/users/~`
+
+        fastify.log.debug({ userInfoUrl }, 'Fetching user info from K8s API')
+
+        const userInfoResponse = await fetch(userInfoUrl, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+          },
+        })
+
+        if (!userInfoResponse.ok) {
+          const errorText = await userInfoResponse.text()
+          fastify.log.error(
+            { status: userInfoResponse.status, body: errorText },
+            'User info fetch failed'
+          )
+          throw new Error(`Failed to fetch user info: ${userInfoResponse.status}`)
+        }
+
+        const userInfo = (await userInfoResponse.json()) as OpenShiftUserInfo
+
+        fastify.log.debug(
+          { username: userInfo.metadata.name, groups: userInfo.groups },
+          'User info retrieved'
+        )
+
+        // Map OpenShift groups to application roles
+        const roles = mapGroupsToRoles(userInfo.groups || [])
+
+        if (roles.length === 0) {
+          fastify.log.warn(
+            { username: userInfo.metadata.name, groups: userInfo.groups },
+            'User has no matching groups for access'
+          )
+          return reply.redirect(
+            `${config.frontendUrl}/?auth_error=${encodeURIComponent('Access denied: You are not a member of sardeenz-admins or sardeenz-admins-readonly groups.')}`
+          )
+        }
+
+        // Create our own JWT
+        const payload: JWTSignPayload = {
+          sub: userInfo.metadata.uid,
+          username: userInfo.metadata.name,
+          roles,
+          authMode: 'oauth',
+        }
+
+        const token = fastify.jwt.sign(payload)
+
+        fastify.log.info(
+          { username: userInfo.metadata.name, roles },
+          'User authenticated successfully via OAuth'
+        )
+
+        // Redirect to frontend with token in URL fragment (more secure than query param)
+        return reply.redirect(`${config.frontendUrl}/#token=${token}`)
+      } catch (error) {
+        fastify.log.error(error, 'OAuth callback error')
+        const message = error instanceof Error ? error.message : 'Authentication failed'
+        return reply.redirect(`${config.frontendUrl}/?auth_error=${encodeURIComponent(message)}`)
+      }
+    }
+  )
+
+  /**
+   * POST /api/auth/logout
+   * Logout endpoint - acknowledges logout request
+   */
+  fastify.post<{ Reply: LogoutResponse }>(
+    '/api/auth/logout',
+    {
+      schema: {
+        tags: ['auth'],
+        description: 'Logout (client should clear token)',
+        response: {
+          200: LogoutResponseSchema,
+        },
+      },
+    },
+    async (): Promise<LogoutResponse> => {
+      // Server-side logout is a no-op for JWT
+      // Client is responsible for clearing the token
+      return { status: 'success' }
+    }
+  )
+
+  /**
+   * GET /api/auth/me
+   * Returns current user information from JWT
+   */
+  fastify.get<{ Reply: CurrentUserResponse | { error: { message: string; type: string } } }>(
+    '/api/auth/me',
+    {
+      schema: {
+        tags: ['auth'],
+        description: 'Get current user information',
+        response: {
+          200: CurrentUserResponseSchema,
+          401: ErrorResponseSchema,
+        },
+      },
+      preHandler: [fastify.authenticate],
+    },
+    async (request, reply): Promise<CurrentUserResponse> => {
+      // If auth is disabled, return a default user
+      if (config.authMode === 'none') {
+        const response: CurrentUserResponse = {
+          username: 'anonymous',
+          roles: ['admin'],
+          authMode: 'simple',
+        }
+        // Include inference API key if configured
+        if (config.inferenceApiKey) {
+          response.inferenceApiKey = config.inferenceApiKey
+        }
+        return response
+      }
+
+      const user = request.user
+      if (!user) {
+        reply.code(401).send({
+          error: {
+            message: 'Not authenticated',
+            type: 'authentication_error',
+          },
+        })
+        return reply
+      }
+
+      const response: CurrentUserResponse = {
+        username: user.username,
+        email: user.email,
+        roles: user.roles,
+        authMode: user.authMode,
+      }
+      // Include inference API key if configured
+      if (config.inferenceApiKey) {
+        response.inferenceApiKey = config.inferenceApiKey
+      }
+      return response
+    }
+  )
+}

--- a/apps/backend/src/routes/benchmarks.ts
+++ b/apps/backend/src/routes/benchmarks.ts
@@ -65,6 +65,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
           400: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       try {
@@ -218,6 +219,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
           200: ListBenchmarksResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request) => {
       const { page = 1, limit = 20, status } = request.query
@@ -266,6 +268,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -370,6 +373,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -418,6 +422,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request, reply) => {
       const { id, sid } = request.params
@@ -477,6 +482,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
           include_warmup: Type.Optional(Type.Boolean({ default: false })),
         }),
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -597,6 +603,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
         description: 'Subscribe to real-time benchmark progress events (SSE)',
         params: BenchmarkIdParamsSchema,
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (
       request: FastifyRequest<{ Params: { id: string } }>,

--- a/apps/backend/src/routes/direct-proxy.ts
+++ b/apps/backend/src/routes/direct-proxy.ts
@@ -8,6 +8,9 @@ import { config } from '../config.js'
  */
 export default async function directProxyRoutes(fastify: FastifyInstance) {
   const debugStreaming = config.debugStreaming
+
+  // Apply inference API key authentication to all routes in this plugin
+  fastify.addHook('preHandler', fastify.authenticateInference)
   /**
    * ALL /api/direct/:port/* - Lightweight port-based proxy
    * Forwards requests directly to localhost:${port}/${path}
@@ -171,7 +174,13 @@ export default async function directProxyRoutes(fastify: FastifyInstance) {
             if (debugStreaming) {
               const durationMs = Date.now() - streamStartTime
               fastify.log.info(
-                { stage: 'stream_complete', targetUrl, totalChunks: chunkIndex, totalBytes, durationMs },
+                {
+                  stage: 'stream_complete',
+                  targetUrl,
+                  totalChunks: chunkIndex,
+                  totalBytes,
+                  durationMs,
+                },
                 `SSE Debug: Stream complete - ${chunkIndex} chunks, ${totalBytes} bytes, ${durationMs}ms (direct proxy)`
               )
             }

--- a/apps/backend/src/routes/events.ts
+++ b/apps/backend/src/routes/events.ts
@@ -47,6 +47,7 @@ export default async function eventsRoutes(fastify: FastifyInstance) {
           ),
         }),
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request: FastifyRequest<{
       Params: { instance_id: string }

--- a/apps/backend/src/routes/gpu.ts
+++ b/apps/backend/src/routes/gpu.ts
@@ -67,8 +67,7 @@ export default async function gpuRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin-readonly'),
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (_request, reply) => {
       try {
@@ -100,6 +99,7 @@ export default async function gpuRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (_request, reply) => {
       try {

--- a/apps/backend/src/routes/local-models.ts
+++ b/apps/backend/src/routes/local-models.ts
@@ -32,6 +32,7 @@ export default async function localModelsRoutes(fastify: FastifyInstance) {
           200: LocalModelsStatusResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async () => {
       return {
@@ -60,6 +61,7 @@ export default async function localModelsRoutes(fastify: FastifyInstance) {
           503: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request, reply) => {
       if (!config.localModelsPath) {

--- a/apps/backend/src/routes/memory-profiles.ts
+++ b/apps/backend/src/routes/memory-profiles.ts
@@ -87,6 +87,7 @@ export default async function memoryProfileRoutes(fastify: FastifyInstance) {
           200: ListMemoryProfilesResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async () => {
       const { profiles, total } = store.listProfiles()
@@ -113,6 +114,7 @@ export default async function memoryProfileRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request, reply) => {
       const { model_path, max_tokens, gpu_name } = request.query
@@ -146,6 +148,7 @@ export default async function memoryProfileRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -181,6 +184,7 @@ export default async function memoryProfileRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const body = request.body
@@ -320,6 +324,7 @@ export default async function memoryProfileRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -358,6 +363,7 @@ export default async function memoryProfileRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -395,6 +401,7 @@ export default async function memoryProfileRoutes(fastify: FastifyInstance) {
           200: MemoryCheckResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request) => {
       const { model_path, max_tokens, gpu_name } = request.body

--- a/apps/backend/src/routes/memory.ts
+++ b/apps/backend/src/routes/memory.ts
@@ -56,8 +56,7 @@ export default async function memoryRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin-readonly'),
+      onRequest: fastify.requireRole('admin-readonly'),
       config: { logRequests: false },
     },
     async (_request, reply) => {
@@ -95,6 +94,7 @@ export default async function memoryRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
       config: { logRequests: false },
     },
     async (_request, reply) => {
@@ -134,8 +134,7 @@ export default async function memoryRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin'),
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { model_path, limit_gb } = request.body

--- a/apps/backend/src/routes/model-configurations.ts
+++ b/apps/backend/src/routes/model-configurations.ts
@@ -68,6 +68,7 @@ export default async function modelConfigurationRoutes(fastify: FastifyInstance)
           200: ListModelConfigurationsResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async () => {
       const { configurations, total } = store.listConfigurations()
@@ -93,6 +94,7 @@ export default async function modelConfigurationRoutes(fastify: FastifyInstance)
           404: ConfigurationErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -127,6 +129,7 @@ export default async function modelConfigurationRoutes(fastify: FastifyInstance)
           409: ConfigurationErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { name, description } = request.body
@@ -178,6 +181,7 @@ export default async function modelConfigurationRoutes(fastify: FastifyInstance)
           409: ConfigurationErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -226,6 +230,7 @@ export default async function modelConfigurationRoutes(fastify: FastifyInstance)
           404: ConfigurationErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { id } = request.params
@@ -266,6 +271,7 @@ export default async function modelConfigurationRoutes(fastify: FastifyInstance)
           400: ConfigurationErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { id } = request.params

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -73,8 +73,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin'),
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const {
@@ -170,8 +169,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin'),
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { model_path } = request.params
@@ -243,8 +241,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           200: ListModelsResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin-readonly'),
+      onRequest: fastify.requireRole('admin-readonly'),
       config: { logRequests: false },
     },
     async () => {
@@ -273,8 +270,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin-readonly'),
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request) => {
       const { model_path } = request.params
@@ -381,8 +377,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin-readonly'),
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request) => {
       const { model_path } = request.params
@@ -418,8 +413,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           500: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin'),
+      onRequest: fastify.requireRole('admin'),
     },
     async (request, reply) => {
       const { instance_id } = request.params
@@ -506,6 +500,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async (request) => {
       const { instance_id } = request.params

--- a/apps/backend/src/routes/orphans.ts
+++ b/apps/backend/src/routes/orphans.ts
@@ -58,8 +58,7 @@ export default async function orphansRoutes(fastify: FastifyInstance) {
           200: OrphanScanResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin'),
+      onRequest: fastify.requireRole('admin-readonly'),
     },
     async () => {
       const result = await orphanDetector.scan()
@@ -97,8 +96,7 @@ export default async function orphansRoutes(fastify: FastifyInstance) {
           404: ErrorResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin'),
+      onRequest: fastify.requireRole('admin'),
     },
     async (request) => {
       const pid = parseInt(request.params.pid, 10)
@@ -133,8 +131,7 @@ export default async function orphansRoutes(fastify: FastifyInstance) {
           200: KillAllOrphansResponseSchema,
         },
       },
-      // TODO: Uncomment when auth is configured
-      // onRequest: fastify.requireRole('admin'),
+      onRequest: fastify.requireRole('admin'),
     },
     async () => {
       return orphanDetector.killAllOrphans()

--- a/apps/backend/src/routes/proxy.ts
+++ b/apps/backend/src/routes/proxy.ts
@@ -213,7 +213,13 @@ async function handleJsonProxyRequest(
       }
 
       // Pipe stream to client - handles TCP_NODELAY, backpressure, and client disconnect
-      await pipeStreamToReply(reply, result.response as Response, model, result.startTime!, fastify.log)
+      await pipeStreamToReply(
+        reply,
+        result.response as Response,
+        model,
+        result.startTime!,
+        fastify.log
+      )
 
       routingTimer({ model, endpoint })
       fastify.sardeenzMetrics.inferenceRequests.inc({
@@ -272,6 +278,9 @@ async function handleJsonProxyRequest(
 
 export default async function proxyRoutes(fastify: FastifyInstance) {
   const proxyRouter = new ProxyRouter(fastify.log)
+
+  // Apply inference API key authentication to all routes in this plugin
+  fastify.addHook('preHandler', fastify.authenticateInference)
 
   // ============================================================
   // OpenAI-Compatible Endpoints (with /v1 prefix)
@@ -570,7 +579,13 @@ export default async function proxyRoutes(fastify: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      return handleAudioProxyRequest(fastify, request, reply, '/v1/audio/transcriptions', proxyRouter)
+      return handleAudioProxyRequest(
+        fastify,
+        request,
+        reply,
+        '/v1/audio/transcriptions',
+        proxyRouter
+      )
     }
   )
 
@@ -622,7 +637,11 @@ async function handleAudioProxyRequest(
 
     // Parse multipart data to extract the model field
     const parts = await request.parts()
-    const formData: { model?: string; fields: Record<string, unknown>; files: Array<{ fieldname: string; file: Buffer; filename: string; mimetype: string }> } = {
+    const formData: {
+      model?: string
+      fields: Record<string, unknown>
+      files: Array<{ fieldname: string; file: Buffer; filename: string; mimetype: string }>
+    } = {
       fields: {},
       files: [],
     }
@@ -698,7 +717,11 @@ async function handleAudioProxyRequest(
     // Add files
     for (const file of formData.files) {
       bodyParts.push(Buffer.from(`--${boundary}\r\n`))
-      bodyParts.push(Buffer.from(`Content-Disposition: form-data; name="${file.fieldname}"; filename="${file.filename}"\r\n`))
+      bodyParts.push(
+        Buffer.from(
+          `Content-Disposition: form-data; name="${file.fieldname}"; filename="${file.filename}"\r\n`
+        )
+      )
       bodyParts.push(Buffer.from(`Content-Type: ${file.mimetype}\r\n\r\n`))
       bodyParts.push(file.file)
       bodyParts.push(Buffer.from('\r\n'))

--- a/apps/backend/src/routes/settings.ts
+++ b/apps/backend/src/routes/settings.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyRequest } from 'fastify'
 import {
   SettingsResponseSchema,
   UpdateSettingsRequestSchema,
@@ -13,6 +13,7 @@ import { runtimeSettings } from '../stores/runtime-settings.js'
 export default async function settingsRoutes(fastify: FastifyInstance) {
   /**
    * GET /api/settings - Get current settings
+   * Note: admin-readonly users see a fake token for security
    */
   fastify.get(
     '/api/settings',
@@ -24,9 +25,23 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
           200: SettingsResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin-readonly'),
     },
-    async () => {
-      return runtimeSettings.getSettingsResponse()
+    async (request: FastifyRequest) => {
+      const settings = runtimeSettings.getSettingsResponse()
+
+      // Check if user is admin-readonly (not admin) - mask the real token
+      const userRoles = request.user?.roles || []
+      const isReadonlyOnly = userRoles.includes('admin-readonly') && !userRoles.includes('admin')
+
+      if (isReadonlyOnly && settings.hf_token) {
+        return {
+          hf_token: 'hf_demo_token',
+          hf_token_source: settings.hf_token_source,
+        }
+      }
+
+      return settings
     }
   )
 
@@ -45,6 +60,7 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
           400: ErrorResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request) => {
       const { hf_token } = request.body
@@ -76,6 +92,7 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
           200: TestHfTokenResponseSchema,
         },
       },
+      onRequest: fastify.requireRole('admin'),
     },
     async (request) => {
       const { token } = request.body

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -38,7 +38,8 @@ await fastify.register(import('@fastify/swagger'), {
     openapi: '3.1.0',
     info: {
       title: 'Sardeenz API',
-      description: 'Multi-model management platform for vLLM with dynamic loading and unified proxy',
+      description:
+        'Multi-model management platform for vLLM with dynamic loading and unified proxy',
       version: '0.1.0',
     },
     servers: [
@@ -47,7 +48,19 @@ await fastify.register(import('@fastify/swagger'), {
         description: 'API Server',
       },
     ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'JWT authentication token',
+        },
+      },
+    },
+    security: config.authMode !== 'none' ? [{ bearerAuth: [] }] : [],
     tags: [
+      { name: 'auth', description: 'Authentication endpoints' },
       { name: 'models', description: 'Model lifecycle management endpoints' },
       { name: 'events', description: 'Real-time event streaming (SSE) endpoints' },
       { name: 'memory', description: 'GPU memory management and profiling endpoints' },
@@ -74,10 +87,44 @@ await fastify.register(import('@fastify/swagger-ui'), {
 // Register metrics plugin
 await fastify.register(import('./plugins/metrics.js'))
 
-// Register auth plugin (if OIDC is configured)
-if (config.oidcIssuerUrl) {
-  await fastify.register(import('./plugins/auth.js'))
-}
+// Register auth plugin (always - handles all auth modes)
+await fastify.register(import('./plugins/auth.js'))
+
+// Register inference auth plugin (handles separate API key auth for inference endpoints)
+await fastify.register(import('./plugins/inference-auth.js'))
+
+// Add global authentication hook for admin routes
+// Note: Inference routes (/v1/*, /api/direct/*, etc.) are excluded and use separate API key auth
+fastify.addHook('onRequest', async (request, reply) => {
+  // Skip if auth mode is 'none'
+  if (config.authMode === 'none') {
+    return
+  }
+
+  // Skip public routes
+  if (fastify.isPublicRoute(request.url)) {
+    return
+  }
+
+  // Skip inference routes - they use separate API key auth (handled by inference-auth plugin)
+  if (fastify.isInferenceRoute(request.url)) {
+    return
+  }
+
+  // Skip authentication for authorization error redirects
+  // This allows authenticated-but-unauthorized users to see the AccessDenied page
+  if (request.url.includes('auth_error=')) {
+    return
+  }
+
+  // Skip static files in production (non-API routes)
+  if (config.nodeEnv === 'production' && !request.url.startsWith('/api/')) {
+    return
+  }
+
+  // Authenticate admin routes with JWT
+  await fastify.authenticate(request, reply)
+})
 
 // Register global error handler (must be before routes)
 await fastify.register(import('./plugins/error-handler.js'))
@@ -91,6 +138,7 @@ await fastify.register(import('@fastify/multipart'), {
 })
 
 // Register routes
+await fastify.register(import('./routes/auth.js'))
 await fastify.register(import('./routes/health.js'))
 await fastify.register(import('./routes/models.js'))
 await fastify.register(import('./routes/events.js'))
@@ -128,8 +176,31 @@ if (config.nodeEnv === 'production') {
     return reply.code(404).send({ error: 'Not Found' })
   })
 } else {
-  // Development: show API info at root
-  fastify.get('/', async () => {
+  // Development: show API info at root, redirect auth errors to frontend
+  fastify.get('/', async (request, reply) => {
+    // Handle authorization error redirects - redirect to frontend
+    const url = new URL(request.url, `http://${request.headers.host}`)
+    if (url.searchParams.has('auth_error')) {
+      const authError = url.searchParams.get('auth_error')
+      const frontendHost = new URL(config.frontendUrl).host
+      const currentHost = request.headers.host
+
+      // Only redirect if frontend is on a different host/port (prevent infinite loop)
+      if (frontendHost !== currentHost) {
+        return reply.redirect(
+          `${config.frontendUrl}/?auth_error=${encodeURIComponent(authError || '')}`
+        )
+      }
+
+      // If same host, return a user-friendly error (shouldn't happen with proper config)
+      return {
+        error: 'Access Denied',
+        message: decodeURIComponent(authError || 'You are not a member of any authorized groups'),
+        resolution:
+          'Please contact your administrator to be added to sardeenz-admins or sardeenz-admins-readonly groups',
+      }
+    }
+
     return {
       name: 'Sardeenz',
       version: '0.1.0',
@@ -162,9 +233,7 @@ async function start() {
       port: config.port,
       host: config.host,
     })
-    logger.info(
-      `Server listening on http://${config.host}:${config.port}`
-    )
+    logger.info(`Server listening on http://${config.host}:${config.port}`)
     logger.info(`Documentation available at http://${config.host}:${config.port}/docs`)
 
     // FR-027: Perform startup orphan detection

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -57,8 +57,16 @@ frontend/
 │   │   ├── Layout/      # AppLayout, NavSidebar
 │   │   ├── LoadConfigurationDialog.tsx   # Load saved model configurations
 │   │   ├── SaveConfigurationDialog.tsx   # Save current models as configuration
-│   │   └── LoadModelDialog.tsx           # Load individual models
+│   │   ├── LoadModelDialog.tsx           # Load individual models
+│   │   └── ProtectedRoute.tsx            # Auth-based route guard
+│   ├── contexts/        # React Context providers
+│   │   ├── AuthContext.tsx           # Authentication state management
+│   │   ├── NotificationContext.tsx   # Toast notifications
+│   │   └── ConnectionContext.tsx     # Backend connection status
 │   ├── pages/           # Route-specific pages
+│   │   ├── Login.tsx         # Login page (simple & OAuth modes)
+│   │   ├── OAuthCallback.tsx # OAuth redirect handler
+│   │   └── ...
 │   ├── services/        # API client layer
 │   ├── App.tsx          # Root component with routing
 │   └── main.tsx         # Entry point

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@sardeenz/frontend",
-  "version": "0.1.0",
   "description": "Frontend dashboard for Sardeenz",
   "private": true,
   "type": "module",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -38,13 +38,23 @@ import {
   Spinner,
   Content,
 } from '@patternfly/react-core'
-import { BarsIcon, SunIcon, MoonIcon, ExclamationCircleIcon, UserIcon } from '@patternfly/react-icons'
+import {
+  BarsIcon,
+  SunIcon,
+  MoonIcon,
+  ExclamationCircleIcon,
+  UserIcon,
+} from '@patternfly/react-icons'
 import sardeenzLogo from '../../../assets/sardeenz.svg'
 import { routes } from './routes'
 import { useNotifications } from './contexts/NotificationContext'
 import { useConnection } from './contexts/ConnectionContext'
+import { useAuth } from './contexts/AuthContext'
 import { NotificationDrawer, NotificationBadgeButton } from './components/NotificationDrawer'
 import { AlertToastGroup } from './components/AlertToastGroup'
+import Login from './pages/Login'
+import OAuthCallback from './pages/OAuthCallback'
+import AccessDenied from './pages/AccessDenied'
 
 function App() {
   const location = useLocation()
@@ -59,6 +69,14 @@ function App() {
 
   const { toastNotifications, removeToastNotification, unreadCount } = useNotifications()
   const { status, retryConnection } = useConnection()
+  const {
+    user,
+    authMode,
+    logout,
+    isAuthenticated,
+    isLoading: authLoading,
+    isAccessDenied,
+  } = useAuth()
 
   // Apply theme to document
   useEffect(() => {
@@ -127,7 +145,12 @@ function App() {
                   isExpanded={isUserDropdownOpen}
                   icon={<UserIcon />}
                 >
-                  User
+                  {user?.username || 'User'}
+                  {user?.roles?.includes('admin')
+                    ? ' (admin)'
+                    : user?.roles?.includes('admin-readonly')
+                      ? ' (admin-readonly)'
+                      : ''}
                 </MenuToggle>
               )}
             >
@@ -136,7 +159,14 @@ function App() {
                   Profile
                 </DropdownItem>
                 <Divider component="li" />
-                <DropdownItem key="logout" isDisabled>
+                <DropdownItem
+                  key="logout"
+                  isDisabled={authMode === 'none'}
+                  onClick={() => {
+                    logout()
+                    onUserDropdownSelect()
+                  }}
+                >
                   Logout
                 </DropdownItem>
               </DropdownList>
@@ -175,7 +205,11 @@ function App() {
         <Nav>
           <NavList>
             {routes.map((route) => (
-              <NavItem key={route.itemId} itemId={route.itemId} isActive={location.pathname === route.path}>
+              <NavItem
+                key={route.itemId}
+                itemId={route.itemId}
+                isActive={location.pathname === route.path}
+              >
                 <Link to={route.path}>{route.label}</Link>
               </NavItem>
             ))}
@@ -190,6 +224,37 @@ function App() {
       <NotificationDrawer onClose={() => setIsDrawerOpen(false)} />
     </DrawerPanelContent>
   )
+
+  // Show auth loading state
+  if (authLoading) {
+    return (
+      <Page masthead={masthead}>
+        <PageSection isFilled>
+          <EmptyState titleText="Initializing..." icon={Spinner}>
+            <EmptyStateBody>
+              <Content component="p">Loading authentication...</Content>
+            </EmptyStateBody>
+          </EmptyState>
+        </PageSection>
+      </Page>
+    )
+  }
+
+  // Show access denied page when user is not in any authorized groups
+  if (!isAuthenticated && authMode !== 'none' && isAccessDenied) {
+    return <AccessDenied />
+  }
+
+  // Show login page for unauthenticated users (when auth is enabled)
+  if (!isAuthenticated && authMode !== 'none') {
+    return (
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/auth/callback" element={<OAuthCallback />} />
+        <Route path="*" element={<Login />} />
+      </Routes>
+    )
+  }
 
   // Show connecting state
   if (status === 'connecting') {
@@ -237,10 +302,7 @@ function App() {
 
   return (
     <>
-      <AlertToastGroup
-        notifications={toastNotifications}
-        onRemove={removeToastNotification}
-      />
+      <AlertToastGroup notifications={toastNotifications} onRemove={removeToastNotification} />
       <Page masthead={masthead} sidebar={sidebar}>
         <Drawer isExpanded={isDrawerOpen} onExpand={() => setIsDrawerOpen(true)}>
           <DrawerContent panelContent={drawerPanelContent}>

--- a/apps/frontend/src/components/LoadConfigurationDialog.tsx
+++ b/apps/frontend/src/components/LoadConfigurationDialog.tsx
@@ -31,6 +31,7 @@ import {
   extractErrorMessage,
   type SavedModelConfigurationResponse,
 } from '../services/api'
+import { useAuth } from '../contexts/AuthContext'
 
 interface LoadConfigurationDialogProps {
   isOpen: boolean
@@ -49,6 +50,7 @@ export function LoadConfigurationDialog({
   onLoadStarted,
   currentModelCount,
 }: LoadConfigurationDialogProps) {
+  const { canWrite } = useAuth()
   const [configurations, setConfigurations] = useState<SavedModelConfigurationResponse[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [selectedConfig, setSelectedConfig] = useState<SavedModelConfigurationResponse | null>(null)
@@ -233,7 +235,8 @@ export function LoadConfigurationDialog({
                           aria-label={`Delete ${config.name}`}
                           onClick={(e) => handleDeleteConfig(config.id, e)}
                           isLoading={isDeleting === config.id}
-                          isDisabled={isDeleting !== null}
+                          isDisabled={isDeleting !== null || !canWrite}
+                          title={!canWrite ? 'You do not have permission to delete configurations' : undefined}
                         >
                           <TrashIcon />
                         </Button>
@@ -283,7 +286,8 @@ export function LoadConfigurationDialog({
           icon={<UploadIcon />}
           onClick={handleLoadConfig}
           isLoading={isLoadingConfig}
-          isDisabled={!selectedConfig || isLoadingConfig}
+          isDisabled={!selectedConfig || isLoadingConfig || !canWrite}
+          title={!canWrite ? 'You do not have permission to load configurations' : undefined}
         >
           Load Configuration
         </Button>

--- a/apps/frontend/src/components/LoadModelDialog.tsx
+++ b/apps/frontend/src/components/LoadModelDialog.tsx
@@ -29,6 +29,7 @@ import type { LoadModelRequest, ModelStatus, GpuAvailabilityResponse, LocalModel
 import { useInstanceEvents } from '../hooks/useInstanceEvents'
 import { LogViewer } from './LogViewer'
 import { apiClient, type MemoryCheckResponse } from '../services/api'
+import { useAuth } from '../contexts/AuthContext'
 
 /** Dialog phase state machine */
 type DialogPhase = 'form' | 'loading' | 'success' | 'failed'
@@ -60,6 +61,9 @@ export function LoadModelDialog({
   onLoad,
   onSuccess,
 }: LoadModelDialogProps) {
+  // Role-based access control
+  const { canWrite } = useAuth()
+
   // Form state
   const [modelPath, setModelPath] = useState('')
   const [maxTokens, setMaxTokens] = useState(4096)
@@ -818,7 +822,12 @@ export function LoadModelDialog({
       <ModalFooter>
         {phase === 'form' && (
           <>
-            <Button variant="primary" onClick={handleSubmit}>
+            <Button
+              variant="primary"
+              onClick={handleSubmit}
+              isDisabled={!canWrite}
+              title={!canWrite ? 'You do not have permission to start models' : undefined}
+            >
               Start Model
             </Button>
             <Button variant="link" onClick={handleClose}>

--- a/apps/frontend/src/components/ModelCard.tsx
+++ b/apps/frontend/src/components/ModelCard.tsx
@@ -26,6 +26,7 @@ import { ModelStatusBadge } from './ModelStatusBadge'
 import { ViewLogsDialog } from './ViewLogsDialog'
 import { MemoryDetailsModal } from './MemoryDetailsModal'
 import { useNotifications } from '../contexts/NotificationContext'
+import { useAuth } from '../contexts/AuthContext'
 
 interface ModelCardProps {
   model: ModelInstanceDTO
@@ -39,6 +40,7 @@ interface ModelCardProps {
  */
 export function ModelCard({ model, onUnload, isUnloading = false }: ModelCardProps) {
   const { addNotification } = useNotifications()
+  const { canWrite } = useAuth()
   const previousErrorRef = useRef<string | null>(null)
   const [logsModalOpen, setLogsModalOpen] = useState(false)
   const [confirmModalOpen, setConfirmModalOpen] = useState(false)
@@ -200,8 +202,9 @@ export function ModelCard({ model, onUnload, isUnloading = false }: ModelCardPro
           variant="danger"
           icon={<TrashIcon />}
           onClick={handleUnloadClick}
-          isDisabled={model.status === 'stopping' || isUnloading}
+          isDisabled={model.status === 'stopping' || isUnloading || !canWrite}
           isLoading={isUnloading}
+          title={!canWrite ? 'You do not have permission to unload models' : undefined}
         >
           {isUnloading
             ? (isFailed ? 'Removing...' : 'Unloading...')

--- a/apps/frontend/src/components/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { Navigate, useLocation } from 'react-router-dom'
+import { Bullseye, Spinner } from '@patternfly/react-core'
+import { useAuth } from '../contexts/AuthContext'
+
+interface ProtectedRouteProps {
+  children: React.ReactNode
+  requiredRoles?: string[]
+}
+
+/**
+ * ProtectedRoute component
+ *
+ * Wraps routes that require authentication. Handles:
+ * - Loading state while auth is initializing
+ * - Redirect to login if not authenticated
+ * - Role-based access control (optional)
+ * - Passes through if auth mode is 'none'
+ */
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requiredRoles }) => {
+  const { isAuthenticated, isLoading, authMode, user } = useAuth()
+  const location = useLocation()
+
+  // Show loading while auth is initializing
+  if (isLoading) {
+    return (
+      <Bullseye>
+        <Spinner aria-label="Loading authentication" />
+      </Bullseye>
+    )
+  }
+
+  // If auth is disabled, allow access
+  if (authMode === 'none') {
+    return <>{children}</>
+  }
+
+  // Redirect to login if not authenticated
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  // Check role requirements if specified
+  if (requiredRoles && requiredRoles.length > 0) {
+    const userRoles = user?.roles || []
+    const hasRequiredRole = requiredRoles.some((role) => userRoles.includes(role))
+
+    if (!hasRequiredRole) {
+      // User doesn't have required role - show forbidden or redirect
+      return (
+        <Bullseye>
+          <div className="pf-v6-u-text-align-center">
+            <h2>Access Denied</h2>
+            <p className="pf-v6-u-mt-md">You don&apos;t have permission to access this page.</p>
+          </div>
+        </Bullseye>
+      )
+    }
+  }
+
+  return <>{children}</>
+}
+
+export default ProtectedRoute

--- a/apps/frontend/src/components/SaveConfigurationDialog.tsx
+++ b/apps/frontend/src/components/SaveConfigurationDialog.tsx
@@ -16,6 +16,7 @@ import {
   Alert,
 } from '@patternfly/react-core'
 import { apiClient, extractErrorMessage } from '../services/api'
+import { useAuth } from '../contexts/AuthContext'
 
 interface SaveConfigurationDialogProps {
   isOpen: boolean
@@ -34,6 +35,7 @@ export function SaveConfigurationDialog({
   onSuccess,
   modelCount,
 }: SaveConfigurationDialogProps) {
+  const { canWrite } = useAuth()
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [isSaving, setIsSaving] = useState(false)
@@ -135,7 +137,13 @@ export function SaveConfigurationDialog({
       </ModalBody>
 
       <ModalFooter>
-        <Button variant="primary" onClick={handleSave} isLoading={isSaving} isDisabled={isSaving}>
+        <Button
+          variant="primary"
+          onClick={handleSave}
+          isLoading={isSaving}
+          isDisabled={isSaving || !canWrite}
+          title={!canWrite ? 'You do not have permission to save configurations' : undefined}
+        >
           Save Configuration
         </Button>
         <Button variant="link" onClick={handleClose} isDisabled={isSaving}>

--- a/apps/frontend/src/components/benchmark/BenchmarkConfigForm.tsx
+++ b/apps/frontend/src/components/benchmark/BenchmarkConfigForm.tsx
@@ -25,6 +25,7 @@ import {
 import { CopyIcon } from '@patternfly/react-icons'
 import { apiClient, extractErrorMessage } from '../../services/api'
 import type { ModelInstanceDTO, RoutingMode } from '@sardeenz/types'
+import { useAuth } from '../../contexts/AuthContext'
 
 /** Token step values for logarithmic-like distribution on sliders */
 const INPUT_TOKEN_STEPS = [64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384]
@@ -107,6 +108,8 @@ export interface BenchmarkFormConfig {
  * Follows PatternFly 6 patterns.
  */
 export function BenchmarkConfigForm({ onSubmit, isSubmitting, initialConfig }: BenchmarkConfigFormProps) {
+  const { canWrite } = useAuth()
+
   // Running instances
   const [runningInstances, setRunningInstances] = useState<ModelInstanceDTO[]>([])
   const [isLoadingInstances, setIsLoadingInstances] = useState(true)
@@ -617,8 +620,9 @@ export function BenchmarkConfigForm({ onSubmit, isSubmitting, initialConfig }: B
               <Button
                 type="submit"
                 variant="primary"
-                isDisabled={!isValid || isSubmitting}
+                isDisabled={!isValid || isSubmitting || !canWrite}
                 isLoading={isSubmitting}
+                title={!canWrite ? 'You do not have permission to run benchmarks' : undefined}
               >
                 {isSubmitting ? 'Starting...' : 'Start Benchmark'}
               </Button>

--- a/apps/frontend/src/components/benchmark/BenchmarkHistoryTable.tsx
+++ b/apps/frontend/src/components/benchmark/BenchmarkHistoryTable.tsx
@@ -32,6 +32,7 @@ import {
 } from '@patternfly/react-core'
 import { TrashIcon, EyeIcon, RedoIcon } from '@patternfly/react-icons'
 import { apiClient, extractErrorMessage, type BenchmarkSummary } from '../../services/api'
+import { useAuth } from '../../contexts/AuthContext'
 
 interface BenchmarkHistoryTableProps {
   onViewBenchmark: (id: string) => void
@@ -43,6 +44,7 @@ interface BenchmarkHistoryTableProps {
  * Table listing past benchmark runs with pagination and filtering.
  */
 export function BenchmarkHistoryTable({ onViewBenchmark, onRerunBenchmark, refreshTrigger }: BenchmarkHistoryTableProps) {
+  const { canWrite } = useAuth()
   const [benchmarks, setBenchmarks] = useState<BenchmarkSummary[]>([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
@@ -258,7 +260,12 @@ export function BenchmarkHistoryTable({ onViewBenchmark, onRerunBenchmark, refre
           </ToolbarItem>
           {selectedIds.length > 0 && (
             <ToolbarItem>
-              <Button variant="danger" onClick={handleBulkDeleteClick}>
+              <Button
+                variant="danger"
+                onClick={handleBulkDeleteClick}
+                isDisabled={!canWrite}
+                title={!canWrite ? 'You do not have permission to delete benchmarks' : undefined}
+              >
                 Delete {selectedIds.length} selected
               </Button>
             </ToolbarItem>
@@ -358,7 +365,8 @@ export function BenchmarkHistoryTable({ onViewBenchmark, onRerunBenchmark, refre
                     icon={<TrashIcon />}
                     aria-label={`Delete benchmark ${benchmark.name || benchmark.id}`}
                     onClick={() => handleDeleteClick(benchmark)}
-                    isDisabled={benchmark.status === 'running'}
+                    isDisabled={benchmark.status === 'running' || !canWrite}
+                    title={!canWrite ? 'You do not have permission to delete benchmarks' : undefined}
                   />
                 </Td>
               </Tr>

--- a/apps/frontend/src/components/benchmark/ProfilesTable.tsx
+++ b/apps/frontend/src/components/benchmark/ProfilesTable.tsx
@@ -28,6 +28,7 @@ import {
 import { TrashIcon, InfoCircleIcon } from '@patternfly/react-icons'
 import type { MemoryProfileResponse } from '../../services/api'
 import { apiClient, extractErrorMessage } from '../../services/api'
+import { useAuth } from '../../contexts/AuthContext'
 
 interface ProfilesTableProps {
   profiles: MemoryProfileResponse[]
@@ -50,6 +51,7 @@ export function ProfilesTable({
   onProfileDeleted,
   onRefresh,
 }: ProfilesTableProps) {
+  const { canWrite } = useAuth()
   const [sortBy, setSortBy] = useState<SortableColumn>('created_at')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
@@ -219,6 +221,8 @@ export function ProfilesTable({
                   icon={<TrashIcon />}
                   aria-label={`Delete profile ${profile.profile_name}`}
                   onClick={() => handleDeleteClick(profile)}
+                  isDisabled={!canWrite}
+                  title={!canWrite ? 'You do not have permission to delete memory profiles' : undefined}
                 />
               </Td>
             </Tr>

--- a/apps/frontend/src/contexts/AuthContext.tsx
+++ b/apps/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,296 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from 'react'
+import { apiClient } from '../services/api'
+import { useConnection } from './ConnectionContext'
+import type { AuthMode, AuthUser, LoginRequest } from '@sardeenz/types'
+
+interface AuthContextType {
+  isAuthenticated: boolean
+  isLoading: boolean
+  user: AuthUser | null
+  authMode: AuthMode
+  error: string | null
+  login: (credentials: LoginRequest) => Promise<void>
+  loginWithOAuth: () => void
+  logout: () => Promise<void>
+  clearError: () => void
+  /** True if user has 'admin' role */
+  isAdmin: boolean
+  /** True if user has 'admin-readonly' but NOT 'admin' */
+  isReadonly: boolean
+  /** Alias for isAdmin - true if user can perform write operations */
+  canWrite: boolean
+  /** True if the error indicates user is not in any authorized groups */
+  isAccessDenied: boolean
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}
+
+interface AuthProviderProps {
+  children: ReactNode
+}
+
+// Session storage key for OAuth callback token
+const OAUTH_TOKEN_KEY = 'sardeenz_oauth_token'
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const { isConnected } = useConnection()
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [authMode, setAuthMode] = useState<AuthMode>('none')
+  const [error, setError] = useState<string | null>(null)
+  const [oauthLoginUrl, setOauthLoginUrl] = useState<string | null>(null)
+
+  // Parse JWT to extract user info without verification (for display only)
+  const parseJwt = useCallback((token: string): AuthUser | null => {
+    try {
+      const parts = token.split('.')
+      if (parts.length !== 3) return null
+      const payload = JSON.parse(atob(parts[1]))
+      return {
+        username: payload.username || payload.preferred_username || 'unknown',
+        email: payload.email,
+        roles: payload.roles || [],
+      }
+    } catch {
+      return null
+    }
+  }, [])
+
+  // Set token and update state
+  const setAuthState = useCallback(
+    async (token: string) => {
+      apiClient.setAuthToken(token)
+      const userInfo = parseJwt(token)
+      setUser(userInfo)
+      setIsAuthenticated(true)
+      setError(null)
+
+      // Fetch additional user info including inference API key
+      try {
+        const currentUser = await apiClient.getCurrentUser()
+        if (currentUser.inferenceApiKey) {
+          apiClient.setInferenceApiKey(currentUser.inferenceApiKey)
+        }
+      } catch {
+        // Ignore errors fetching additional user info
+      }
+
+      // Calculate token expiration and set timer
+      try {
+        const parts = token.split('.')
+        if (parts.length === 3) {
+          const payload = JSON.parse(atob(parts[1]))
+          if (payload.exp) {
+            const expiresIn = payload.exp * 1000 - Date.now()
+            if (expiresIn > 0) {
+              // Auto-logout when token expires (with 1 minute buffer)
+              const timeout = Math.max(expiresIn - 60000, 0)
+              setTimeout(() => {
+                setIsAuthenticated(false)
+                setUser(null)
+                apiClient.setAuthToken(null)
+                apiClient.setInferenceApiKey(null)
+              }, timeout)
+            }
+          }
+        }
+      } catch {
+        // Ignore parsing errors for expiration
+      }
+    },
+    [parseJwt]
+  )
+
+  // Initialize auth state when connection is available
+  useEffect(() => {
+    // Wait for backend connection before fetching auth info
+    if (!isConnected) {
+      return
+    }
+
+    const initAuth = async () => {
+      try {
+        // Fetch auth configuration
+        const authInfo = await apiClient.getAuthInfo()
+        setAuthMode(authInfo.mode)
+
+        if (authInfo.oauthLoginUrl) {
+          setOauthLoginUrl(authInfo.oauthLoginUrl)
+        }
+
+        // If auth is disabled, we're authenticated by default
+        if (authInfo.mode === 'none') {
+          setIsAuthenticated(true)
+          setUser({ username: 'anonymous', roles: ['admin'] })
+          // Fetch inference API key even when auth is disabled
+          try {
+            const currentUser = await apiClient.getCurrentUser()
+            if (currentUser.inferenceApiKey) {
+              apiClient.setInferenceApiKey(currentUser.inferenceApiKey)
+            }
+          } catch {
+            // Ignore errors
+          }
+          setIsLoading(false)
+          return
+        }
+
+        // Check for OAuth callback token in URL hash
+        const hash = window.location.hash
+        if (hash.startsWith('#token=')) {
+          const token = hash.substring(7)
+          setAuthState(token)
+          // Clean up URL
+          window.history.replaceState(null, '', window.location.pathname + window.location.search)
+          setIsLoading(false)
+          return
+        }
+
+        // Check for token in session storage (from OAuth callback)
+        const storedToken = sessionStorage.getItem(OAUTH_TOKEN_KEY)
+        if (storedToken) {
+          sessionStorage.removeItem(OAUTH_TOKEN_KEY)
+          setAuthState(storedToken)
+          setIsLoading(false)
+          return
+        }
+
+        // Check for auth error in URL
+        const urlParams = new URLSearchParams(window.location.search)
+        const authError = urlParams.get('auth_error')
+        if (authError) {
+          setError(decodeURIComponent(authError))
+          // Clean up URL
+          urlParams.delete('auth_error')
+          const newSearch = urlParams.toString()
+          window.history.replaceState(
+            null,
+            '',
+            window.location.pathname + (newSearch ? '?' + newSearch : '')
+          )
+        }
+
+        // No token found, user needs to authenticate
+        setIsLoading(false)
+      } catch (err) {
+        console.error('Failed to initialize auth:', err)
+        setError('Failed to connect to server')
+        setIsLoading(false)
+      }
+    }
+
+    initAuth()
+  }, [isConnected, setAuthState])
+
+  // Listen for unauthorized events from API client
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      setIsAuthenticated(false)
+      setUser(null)
+      apiClient.setAuthToken(null)
+      apiClient.setInferenceApiKey(null)
+      setError('Session expired. Please log in again.')
+    }
+
+    window.addEventListener('auth:unauthorized', handleUnauthorized)
+    return () => window.removeEventListener('auth:unauthorized', handleUnauthorized)
+  }, [])
+
+  // Login with username/password (simple mode)
+  const login = useCallback(async (credentials: LoginRequest) => {
+    setError(null)
+    try {
+      const response = await apiClient.login(credentials)
+      apiClient.setAuthToken(response.token)
+      setUser(response.user)
+      setIsAuthenticated(true)
+      // Fetch additional user info including inference API key
+      try {
+        const currentUser = await apiClient.getCurrentUser()
+        if (currentUser.inferenceApiKey) {
+          apiClient.setInferenceApiKey(currentUser.inferenceApiKey)
+        }
+      } catch {
+        // Ignore errors fetching additional user info
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : (err as { response?: { data?: { error?: { message?: string } } } })?.response?.data
+              ?.error?.message || 'Login failed'
+      setError(message)
+      throw err
+    }
+  }, [])
+
+  // Redirect to OAuth login
+  const loginWithOAuth = useCallback(() => {
+    if (oauthLoginUrl) {
+      window.location.href = oauthLoginUrl
+    } else {
+      setError('OAuth login is not configured')
+    }
+  }, [oauthLoginUrl])
+
+  // Logout
+  const logout = useCallback(async () => {
+    try {
+      await apiClient.logout()
+    } catch {
+      // Ignore logout errors
+    }
+    apiClient.setAuthToken(null)
+    apiClient.setInferenceApiKey(null)
+    setUser(null)
+    setIsAuthenticated(false)
+    setError(null)
+  }, [])
+
+  // Clear error
+  const clearError = useCallback(() => {
+    setError(null)
+  }, [])
+
+  // Role helper computed values
+  const isAdmin = user?.roles?.includes('admin') ?? false
+  const isReadonly = (user?.roles?.includes('admin-readonly') ?? false) && !isAdmin
+  const canWrite = isAdmin
+
+  // Detect access denied error (user not in any authorized groups)
+  const isAccessDenied = error?.includes('not a member') ?? false
+
+  const value: AuthContextType = {
+    isAuthenticated,
+    isLoading,
+    user,
+    authMode,
+    error,
+    login,
+    loginWithOAuth,
+    logout,
+    clearError,
+    isAdmin,
+    isReadonly,
+    canWrite,
+    isAccessDenied,
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -5,16 +5,19 @@ import '@patternfly/react-core/dist/styles/base.css'
 import '@patternfly/chatbot/dist/css/main.css'
 import App from './App'
 import { NotificationProvider } from './contexts/NotificationContext'
+import { AuthProvider } from './contexts/AuthContext'
 import { ConnectionProvider } from './contexts/ConnectionContext'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <NotificationProvider>
-      <ConnectionProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </ConnectionProvider>
+      <BrowserRouter>
+        <ConnectionProvider>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </ConnectionProvider>
+      </BrowserRouter>
     </NotificationProvider>
   </React.StrictMode>
 )

--- a/apps/frontend/src/pages/AccessDenied.tsx
+++ b/apps/frontend/src/pages/AccessDenied.tsx
@@ -1,0 +1,82 @@
+import {
+  Page,
+  PageSection,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
+  Button,
+  Content,
+  ContentVariants,
+  Masthead,
+  MastheadMain,
+  MastheadBrand,
+  MastheadLogo,
+  Brand,
+} from '@patternfly/react-core'
+import { LockIcon } from '@patternfly/react-icons'
+import { useAuth } from '../contexts/AuthContext'
+import sardeenzLogo from '../../../../assets/sardeenz.svg'
+
+/**
+ * Access Denied page shown when a user authenticates via OAuth
+ * but is not a member of any authorized groups.
+ */
+export function AccessDenied() {
+  const { logout, clearError } = useAuth()
+
+  const handleTryAgain = () => {
+    clearError()
+    logout()
+  }
+
+  const masthead = (
+    <Masthead>
+      <MastheadMain>
+        <MastheadBrand>
+          <MastheadLogo>
+            <Brand src={sardeenzLogo} alt="Sardeenz" heights={{ default: '48px' }} />
+          </MastheadLogo>
+        </MastheadBrand>
+      </MastheadMain>
+    </Masthead>
+  )
+
+  return (
+    <Page masthead={masthead}>
+      <PageSection isFilled>
+        <EmptyState titleText="Access Denied" headingLevel="h1" icon={LockIcon} status="danger">
+          <EmptyStateBody>
+            <Content component={ContentVariants.p}>
+              You are not a member of any authorized groups for this application.
+            </Content>
+            <Content component={ContentVariants.p}>
+              To access Sardeenz, you must be added to one of the following OpenShift groups:
+            </Content>
+            <Content component="ul" style={{ textAlign: 'left', display: 'inline-block' }}>
+              <li>
+                <strong>sardeenz-admins</strong> - Full access (load/unload models, manage settings)
+              </li>
+              <li>
+                <strong>sardeenz-admins-readonly</strong> - Read-only access (view models, run
+                tests)
+              </li>
+            </Content>
+            <Content component={ContentVariants.p}>
+              Please contact your OpenShift administrator to request access.
+            </Content>
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button variant="primary" onClick={handleTryAgain}>
+                Try Again
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      </PageSection>
+    </Page>
+  )
+}
+
+export default AccessDenied

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import {
+  LoginPage,
+  LoginForm,
+  ListItem,
+  ListVariant,
+} from '@patternfly/react-core'
+import { ExclamationCircleIcon } from '@patternfly/react-icons'
+import { useAuth } from '../contexts/AuthContext'
+
+export const Login: React.FC = () => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { authMode, login, loginWithOAuth, error, clearError, isLoading } = useAuth()
+
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Get the redirect path from location state, or default to home
+  const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/'
+
+  const handleUsernameChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    setUsername(value)
+    if (error) clearError()
+  }
+
+  const handlePasswordChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    setPassword(value)
+    if (error) clearError()
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!username || !password) return
+
+    setIsSubmitting(true)
+    try {
+      await login({ username, password })
+      navigate(from, { replace: true })
+    } catch {
+      // Error is handled in AuthContext
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleOAuthLogin = () => {
+    loginWithOAuth()
+  }
+
+  // Show loading while auth is initializing
+  if (isLoading) {
+    return (
+      <div className="pf-v6-u-display-flex pf-v6-u-justify-content-center pf-v6-u-align-items-center pf-v6-u-h-100">
+        <span>Loading...</span>
+      </div>
+    )
+  }
+
+  // For OAuth mode, show SSO button
+  if (authMode === 'oauth') {
+    return (
+      <LoginPage
+        loginTitle="Log in to Sardeenz"
+        loginSubtitle="Multi-model management platform"
+        textContent="Use your organization's single sign-on to access the platform."
+        socialMediaLoginContent={
+          <div className="pf-v6-u-mt-md">
+            <button
+              className="pf-v6-c-button pf-m-primary pf-m-block"
+              onClick={handleOAuthLogin}
+              type="button"
+            >
+              Log in with SSO
+            </button>
+          </div>
+        }
+        footerListItems={
+          <>
+            <ListItem>
+              <a href="#">Terms of Use</a>
+            </ListItem>
+            <ListItem>
+              <a href="#">Help</a>
+            </ListItem>
+          </>
+        }
+        footerListVariants={ListVariant.inline}
+      >
+        {error && (
+          <div className="pf-v6-u-mb-md pf-v6-u-color-danger">
+            <ExclamationCircleIcon /> {error}
+          </div>
+        )}
+      </LoginPage>
+    )
+  }
+
+  // For simple mode, show username/password form
+  return (
+    <LoginPage
+      loginTitle="Log in to Sardeenz"
+      loginSubtitle="Multi-model management platform"
+      footerListItems={
+        <>
+          <ListItem>
+            <a href="#">Terms of Use</a>
+          </ListItem>
+          <ListItem>
+            <a href="#">Help</a>
+          </ListItem>
+        </>
+      }
+      footerListVariants={ListVariant.inline}
+    >
+      <LoginForm
+        showHelperText={!!error}
+        helperText={error || ''}
+        helperTextIcon={<ExclamationCircleIcon />}
+        usernameLabel="Username"
+        usernameValue={username}
+        onChangeUsername={handleUsernameChange}
+        isValidUsername={!error}
+        passwordLabel="Password"
+        passwordValue={password}
+        onChangePassword={handlePasswordChange}
+        isShowPasswordEnabled
+        showPasswordAriaLabel="Show password"
+        isValidPassword={!error}
+        onLoginButtonClick={handleSubmit}
+        loginButtonLabel={isSubmitting ? 'Logging in...' : 'Log in'}
+        isLoginButtonDisabled={isSubmitting || !username || !password}
+      />
+    </LoginPage>
+  )
+}
+
+export default Login

--- a/apps/frontend/src/pages/ModelBenchmark.tsx
+++ b/apps/frontend/src/pages/ModelBenchmark.tsx
@@ -21,6 +21,7 @@ import {
 } from '../components/benchmark'
 import type { BenchmarkFormConfig, InitialBenchmarkConfig } from '../components/benchmark'
 import { apiClient, extractErrorMessage } from '../services/api'
+import { useAuth } from '../contexts/AuthContext'
 
 /** Performance tab view state machine */
 type PerformanceView = 'list' | 'form' | 'running' | 'results'
@@ -30,6 +31,7 @@ type PerformanceView = 'list' | 'form' | 'running' | 'results'
  * Performance tab supports running benchmarks with real-time progress.
  */
 function ModelBenchmark() {
+  const { canWrite } = useAuth()
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0)
 
   // Performance tab state
@@ -149,7 +151,12 @@ function ModelBenchmark() {
               style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}
             >
               <FlexItem>
-                <Button variant="primary" onClick={handleStartNewBenchmark}>
+                <Button
+                  variant="primary"
+                  onClick={handleStartNewBenchmark}
+                  isDisabled={!canWrite}
+                  title={!canWrite ? 'You do not have permission to run benchmarks' : undefined}
+                >
                   New Benchmark
                 </Button>
               </FlexItem>

--- a/apps/frontend/src/pages/OAuthCallback.tsx
+++ b/apps/frontend/src/pages/OAuthCallback.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Bullseye, Spinner } from '@patternfly/react-core'
+
+/**
+ * OAuth Callback Handler
+ *
+ * This page handles the redirect from the OAuth provider.
+ * The backend redirects here with the token in the URL hash: /#token=...
+ *
+ * The AuthContext handles extracting the token on mount, so this component
+ * just shows a loading spinner and redirects to home.
+ */
+export const OAuthCallback: React.FC = () => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    // The AuthContext will handle the token extraction from the URL hash
+    // We just need to wait a moment and redirect to home
+    const timer = setTimeout(() => {
+      navigate('/', { replace: true })
+    }, 100)
+
+    return () => clearTimeout(timer)
+  }, [navigate])
+
+  return (
+    <Bullseye>
+      <div className="pf-v6-u-text-align-center">
+        <Spinner aria-label="Completing authentication" />
+        <div className="pf-v6-u-mt-md">Completing authentication...</div>
+      </div>
+    </Bullseye>
+  )
+}
+
+export default OAuthCallback

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -26,10 +26,12 @@ import {
 import { EyeIcon, EyeSlashIcon, CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons'
 import { apiClient } from '../services/api'
 import { useNotifications } from '../contexts/NotificationContext'
+import { useAuth } from '../contexts/AuthContext'
 import type { SettingsResponse } from '@sardeenz/types'
 
 function Settings() {
   const { addNotification } = useNotifications()
+  const { canWrite } = useAuth()
 
   // Settings state
   const [settings, setSettings] = useState<SettingsResponse | null>(null)
@@ -291,7 +293,8 @@ function Settings() {
                           variant="secondary"
                           onClick={handleTestToken}
                           isLoading={testing}
-                          isDisabled={testing || saving || (!hfToken.trim() && !settings?.hf_token)}
+                          isDisabled={testing || saving || (!hfToken.trim() && !settings?.hf_token) || !canWrite}
+                          title={!canWrite ? 'You do not have permission to test tokens' : undefined}
                         >
                           Test Connection
                         </Button>
@@ -301,7 +304,8 @@ function Settings() {
                           variant="primary"
                           onClick={handleSaveToken}
                           isLoading={saving}
-                          isDisabled={saving || testing || !hfToken.trim()}
+                          isDisabled={saving || testing || !hfToken.trim() || !canWrite}
+                          title={!canWrite ? 'You do not have permission to modify settings' : undefined}
                         >
                           Save Token
                         </Button>
@@ -312,7 +316,8 @@ function Settings() {
                             variant="link"
                             isDanger
                             onClick={handleClearToken}
-                            isDisabled={saving || testing}
+                            isDisabled={saving || testing || !canWrite}
+                            title={!canWrite ? 'You do not have permission to modify settings' : undefined}
                           >
                             Clear Token
                           </Button>

--- a/apps/frontend/src/routes.tsx
+++ b/apps/frontend/src/routes.tsx
@@ -19,10 +19,10 @@ export const routes: RouteConfig[] = [
     itemId: 'model-management',
   },
   {
-    path: '/gpu',
-    element: <GpuInfo />,
-    label: 'GPU Info',
-    itemId: 'gpu-info',
+    path: '/inference-tests',
+    element: <InferenceTests />,
+    label: 'Inference Tests',
+    itemId: 'inference-tests',
   },
   {
     path: '/benchmark',
@@ -31,10 +31,10 @@ export const routes: RouteConfig[] = [
     itemId: 'model-benchmark',
   },
   {
-    path: '/inference-tests',
-    element: <InferenceTests />,
-    label: 'Inference Tests',
-    itemId: 'inference-tests',
+    path: '/gpu',
+    element: <GpuInfo />,
+    label: 'GPU Info',
+    itemId: 'gpu-info',
   },
   {
     path: '/settings',

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -20,6 +20,10 @@ import type {
   MultiGpuMemoryUsageResponse,
   ListLocalModelsResponse,
   LocalModelsStatusResponse,
+  AuthInfoResponse,
+  LoginRequest,
+  LoginResponse,
+  CurrentUserResponse,
 } from '@sardeenz/types'
 
 // Memory Profile types for API responses
@@ -318,6 +322,8 @@ export function extractErrorMessage(error: unknown): string {
 
 class ApiClient {
   private client: AxiosInstance
+  private authToken: string | null = null
+  private inferenceApiKey: string | null = null
 
   constructor() {
     const baseURL = import.meta.env.VITE_API_BASE_URL || ''
@@ -330,10 +336,39 @@ class ApiClient {
       },
     })
 
-    // Add retry interceptor for connection errors
+    // Add request interceptor to include auth token
+    // Uses inference API key for inference routes, JWT for admin routes
+    this.client.interceptors.request.use((config) => {
+      const url = config.url || ''
+      const isInferenceRoute =
+        url.startsWith('/v1/') ||
+        url.startsWith('/tokenize') ||
+        url.startsWith('/detokenize') ||
+        url.startsWith('/pooling') ||
+        url.startsWith('/classification') ||
+        url.startsWith('/score') ||
+        url.startsWith('/re-rank') ||
+        url.startsWith('/api/direct/')
+
+      if (isInferenceRoute && this.inferenceApiKey) {
+        // Use inference API key for inference routes
+        config.headers.Authorization = `Bearer ${this.inferenceApiKey}`
+      } else if (this.authToken) {
+        // Use JWT for admin routes
+        config.headers.Authorization = `Bearer ${this.authToken}`
+      }
+      return config
+    })
+
+    // Add response interceptor for connection errors and 401 handling
     this.client.interceptors.response.use(
       (response) => response,
       async (error: AxiosError) => {
+        // Handle 401 Unauthorized - emit event for AuthContext
+        if (error.response?.status === 401) {
+          window.dispatchEvent(new CustomEvent('auth:unauthorized'))
+        }
+
         const config = error.config as RetryableRequestConfig | undefined
         if (!config) return Promise.reject(error)
 
@@ -359,6 +394,46 @@ class ApiClient {
         return this.client.request(config)
       }
     )
+  }
+
+  // Auth token management
+  setAuthToken(token: string | null): void {
+    this.authToken = token
+  }
+
+  getAuthToken(): string | null {
+    return this.authToken
+  }
+
+  // Inference API key management (separate from admin JWT auth)
+  setInferenceApiKey(key: string | null): void {
+    this.inferenceApiKey = key
+  }
+
+  getInferenceApiKey(): string | null {
+    return this.inferenceApiKey
+  }
+
+  // Authentication endpoints
+
+  async getAuthInfo(): Promise<AuthInfoResponse> {
+    const response = await this.client.get<AuthInfoResponse>('/api/auth/info')
+    return response.data
+  }
+
+  async login(credentials: LoginRequest): Promise<LoginResponse> {
+    const response = await this.client.post<LoginResponse>('/api/auth/login', credentials)
+    return response.data
+  }
+
+  async logout(): Promise<void> {
+    await this.client.post('/api/auth/logout')
+    this.authToken = null
+  }
+
+  async getCurrentUser(): Promise<CurrentUserResponse> {
+    const response = await this.client.get<CurrentUserResponse>('/api/auth/me')
+    return response.data
   }
 
   // Model management endpoints
@@ -394,9 +469,7 @@ class ApiClient {
 
   async getModelHealth(modelPath: string): Promise<ModelHealthResponse> {
     const encodedPath = encodeURIComponent(modelPath)
-    const response = await this.client.get<ModelHealthResponse>(
-      `/api/models/${encodedPath}/health`
-    )
+    const response = await this.client.get<ModelHealthResponse>(`/api/models/${encodedPath}/health`)
     return response.data
   }
 
@@ -415,10 +488,7 @@ class ApiClient {
   }
 
   async setMemoryLimits(request: SetMemoryLimitsRequest): Promise<SetMemoryLimitsResponse> {
-    const response = await this.client.post<SetMemoryLimitsResponse>(
-      '/api/memory/limits',
-      request
-    )
+    const response = await this.client.post<SetMemoryLimitsResponse>('/api/memory/limits', request)
     return response.data
   }
 
@@ -442,7 +512,9 @@ class ApiClient {
   }
 
   async getMultiGpuMemoryUsage(): Promise<MultiGpuMemoryUsageResponse> {
-    const response = await this.client.get<MultiGpuMemoryUsageResponse>('/api/memory/usage/multi-gpu')
+    const response = await this.client.get<MultiGpuMemoryUsageResponse>(
+      '/api/memory/usage/multi-gpu'
+    )
     return response.data
   }
 
@@ -483,10 +555,7 @@ class ApiClient {
   async sendChatCompletionViaProxy(
     request: ChatCompletionRequest
   ): Promise<ChatCompletionResponse> {
-    const response = await this.client.post<ChatCompletionResponse>(
-      '/v1/chat/completions',
-      request
-    )
+    const response = await this.client.post<ChatCompletionResponse>('/v1/chat/completions', request)
     return response.data
   }
 
@@ -524,9 +593,14 @@ class ApiClient {
 
     try {
       const baseURL = import.meta.env.VITE_API_BASE_URL || ''
+      // Build headers - include inference API key if available
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (this.inferenceApiKey) {
+        headers['Authorization'] = `Bearer ${this.inferenceApiKey}`
+      }
       const response = await fetch(`${baseURL}/v1/chat/completions`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({
           ...request,
           stream: true,
@@ -632,9 +706,14 @@ class ApiClient {
 
     try {
       const baseURL = import.meta.env.VITE_API_BASE_URL || ''
+      // Build headers - include inference API key if available
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (this.inferenceApiKey) {
+        headers['Authorization'] = `Bearer ${this.inferenceApiKey}`
+      }
       const response = await fetch(`${baseURL}/api/direct/${port}/v1/chat/completions`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({
           ...request,
           stream: true,
@@ -777,15 +856,20 @@ class ApiClient {
     return response.data
   }
 
-  async getBenchmark(id: string): Promise<{ benchmark: BenchmarkSummary & { scenarios: unknown[] } }> {
-    const response = await this.client.get<{ benchmark: BenchmarkSummary & { scenarios: unknown[] } }>(
-      `/api/benchmarks/${id}`
-    )
+  async getBenchmark(
+    id: string
+  ): Promise<{ benchmark: BenchmarkSummary & { scenarios: unknown[] } }> {
+    const response = await this.client.get<{
+      benchmark: BenchmarkSummary & { scenarios: unknown[] }
+    }>(`/api/benchmarks/${id}`)
     return response.data
   }
 
   async createBenchmark(data: CreateBenchmarkRequest): Promise<{ benchmark: BenchmarkSummary }> {
-    const response = await this.client.post<{ benchmark: BenchmarkSummary }>('/api/benchmarks', data)
+    const response = await this.client.post<{ benchmark: BenchmarkSummary }>(
+      '/api/benchmarks',
+      data
+    )
     return response.data
   }
 
@@ -794,7 +878,11 @@ class ApiClient {
     return response.data
   }
 
-  async exportBenchmark(id: string, format: 'csv' | 'json' = 'csv', includeWarmup = false): Promise<Blob> {
+  async exportBenchmark(
+    id: string,
+    format: 'csv' | 'json' = 'csv',
+    includeWarmup = false
+  ): Promise<Blob> {
     const response = await this.client.post(
       `/api/benchmarks/${id}/export`,
       { format, include_warmup: includeWarmup },
@@ -826,12 +914,19 @@ class ApiClient {
   }
 
   async getConfiguration(id: string): Promise<GetModelConfigurationResponse> {
-    const response = await this.client.get<GetModelConfigurationResponse>(`/api/configurations/${id}`)
+    const response = await this.client.get<GetModelConfigurationResponse>(
+      `/api/configurations/${id}`
+    )
     return response.data
   }
 
-  async saveConfiguration(data: CreateModelConfigurationRequest): Promise<GetModelConfigurationResponse> {
-    const response = await this.client.post<GetModelConfigurationResponse>('/api/configurations', data)
+  async saveConfiguration(
+    data: CreateModelConfigurationRequest
+  ): Promise<GetModelConfigurationResponse> {
+    const response = await this.client.post<GetModelConfigurationResponse>(
+      '/api/configurations',
+      data
+    )
     return response.data
   }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,29 +6,29 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 
 ### 📚 Core Documentation
 
-| Document | Description |
-|----------|-------------|
-| [**Architecture Overview**](./architecture.md) | High-level system architecture, design decisions, and technical details |
-| [**Backend Architecture**](./architecture/backend-architecture.md) | Detailed backend components, flows, and process management |
-| [**Frontend Architecture**](./architecture/frontend-architecture.md) | Frontend component specs, state management, and API integration |
-| [**API Guide**](./api-guide.md) | API reference with code examples for Controller and Proxy APIs |
-| [**Deployment Guide**](./deployment.md) | Container building and OpenShift/Kubernetes deployment |
+| Document                                                             | Description                                                             |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [**Architecture Overview**](./architecture.md)                       | High-level system architecture, design decisions, and technical details |
+| [**Backend Architecture**](./architecture/backend-architecture.md)   | Detailed backend components, flows, and process management              |
+| [**Frontend Architecture**](./architecture/frontend-architecture.md) | Frontend component specs, state management, and API integration         |
+| [**API Guide**](./api-guide.md)                                      | API reference with code examples for Controller and Proxy APIs          |
+| [**Deployment Guide**](./deployment.md)                              | Container building and OpenShift/Kubernetes deployment                  |
 
 ### 🛠️ Development Guides
 
-| Resource | Description |
-|----------|-------------|
-| [**Development Setup**](./dev-setup.md) | GPU development environment setup (vLLM, KVCached, uv) |
-| [**PatternFly 6 Guide**](./development/pf6-guide/README.md) | Complete UI development guide with PatternFly 6 |
-| [**Frontend API Client**](./development/frontend-api-client.md) | API client integration for the frontend |
+| Resource                                                        | Description                                            |
+| --------------------------------------------------------------- | ------------------------------------------------------ |
+| [**Development Setup**](./dev-setup.md)                         | GPU development environment setup (vLLM, KVCached, uv) |
+| [**PatternFly 6 Guide**](./development/pf6-guide/README.md)     | Complete UI development guide with PatternFly 6        |
+| [**Frontend API Client**](./development/frontend-api-client.md) | API client integration for the frontend                |
 
 ### 🔧 Technical Resources
 
-| Resource | Description |
-|----------|-------------|
-| [**KVCached**](./kvcached/) | GPU memory sharing documentation and setup guides |
+| Resource                                                 | Description                                                |
+| -------------------------------------------------------- | ---------------------------------------------------------- |
+| [**KVCached**](./kvcached/)                              | GPU memory sharing documentation and setup guides          |
 | [**Specifications**](../specs/001-multi-model-platform/) | Design specifications, planning documents, and data models |
-| [**Changelog**](../CHANGELOG.md) | Project change history |
+| [**Changelog**](../CHANGELOG.md)                         | Project change history                                     |
 
 ### 🚀 Getting Started
 
@@ -64,6 +64,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 - [Specifications](../specs/001-multi-model-platform/spec.md) - Feature requirements
 
 **Key Files:**
+
 - `apps/backend/` - Fastify backend source code
 - `apps/frontend/` - React + PatternFly dashboard
 - `packages/types/` - Shared TypeScript types
@@ -78,9 +79,10 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 - [Deployment Guide: Troubleshooting](./deployment.md#troubleshooting) - Common issues
 
 **Key Resources:**
+
 - GPU-enabled OpenShift cluster setup
 - Model storage (PVC or S3)
-- OAuth/OIDC integration
+- OAuth 2.0 integration (OpenShift OAuth)
 
 ### 📊 Data Scientists / ML Engineers
 
@@ -92,6 +94,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 - [Architecture: Memory Management](./architecture.md#memory-management) - GPU allocation strategy
 
 **Supported Models:**
+
 - Any model compatible with vLLM (Llama, Mistral, Qwen, etc.)
 - HuggingFace format or local paths
 
@@ -106,6 +109,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 - [CLAUDE.md](../CLAUDE.md#common-commands) - Frontend development commands
 
 **Key Files:**
+
 - `apps/frontend/src/components/` - Reusable UI components
 - `apps/frontend/src/pages/` - Page-level components
 - `apps/frontend/src/hooks/` - Custom React hooks
@@ -114,50 +118,51 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 
 ### Architecture & Design
 
-| Document | Topics Covered |
-|----------|----------------|
-| [architecture.md](./architecture.md) | System overview, technology stack, component architecture, data model, security, performance |
-| [architecture/backend-architecture.md](./architecture/backend-architecture.md) | Backend components, model loading flows, process management, GPU memory tracking |
-| [architecture/frontend-architecture.md](./architecture/frontend-architecture.md) | Frontend components, state management, routing, API integration, real-time updates |
-| [specs/spec.md](../specs/001-multi-model-platform/spec.md) | Feature requirements, priorities, user stories |
-| [specs/plan.md](../specs/001-multi-model-platform/plan.md) | Implementation plan, milestones, timeline |
-| [specs/data-model.md](../specs/001-multi-model-platform/data-model.md) | Entity schemas, relationships, validation rules |
+| Document                                                                         | Topics Covered                                                                               |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [architecture.md](./architecture.md)                                             | System overview, technology stack, component architecture, data model, security, performance |
+| [architecture/backend-architecture.md](./architecture/backend-architecture.md)   | Backend components, model loading flows, process management, GPU memory tracking             |
+| [architecture/frontend-architecture.md](./architecture/frontend-architecture.md) | Frontend components, state management, routing, API integration, real-time updates           |
+| [specs/spec.md](../specs/001-multi-model-platform/spec.md)                       | Feature requirements, priorities, user stories                                               |
+| [specs/plan.md](../specs/001-multi-model-platform/plan.md)                       | Implementation plan, milestones, timeline                                                    |
+| [specs/data-model.md](../specs/001-multi-model-platform/data-model.md)           | Entity schemas, relationships, validation rules                                              |
 
 ### API & Integration
 
-| Document | Topics Covered |
-|----------|----------------|
-| [api-guide.md](./api-guide.md) | Controller API (load/unload models), Proxy API (inference), authentication, error handling, code examples (Python, JavaScript, curl) |
-| [specs/contracts/](../specs/001-multi-model-platform/contracts/) | OpenAPI 3.1 specifications (when available) |
+| Document                                                         | Topics Covered                                                                                                                       |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [api-guide.md](./api-guide.md)                                   | Controller API (load/unload models), Proxy API (inference), authentication, error handling, code examples (Python, JavaScript, curl) |
+| [specs/contracts/](../specs/001-multi-model-platform/contracts/) | OpenAPI 3.1 specifications (when available)                                                                                          |
 
 ### Deployment & Operations
 
-| Document | Topics Covered |
-|----------|----------------|
+| Document                         | Topics Covered                                                                                                   |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | [deployment.md](./deployment.md) | Container build, Docker Compose, OpenShift deployment, configuration, health checks, monitoring, troubleshooting |
-| [kvcached/](./kvcached/) | KVCached installation, configuration, memory segment management |
+| [kvcached/](./kvcached/)         | KVCached installation, configuration, memory segment management                                                  |
 
 ### Development Guides
 
-| Document | Topics Covered |
-|----------|----------------|
-| [dev-setup.md](./dev-setup.md) | GPU development environment, vLLM setup, KVCached configuration |
-| [development/pf6-guide/](./development/pf6-guide/README.md) | PatternFly 6 components, styling standards, testing patterns, troubleshooting |
-| [development/frontend-api-client.md](./development/frontend-api-client.md) | Axios setup, API client patterns, error handling |
+| Document                                                                   | Topics Covered                                                                |
+| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [dev-setup.md](./dev-setup.md)                                             | GPU development environment, vLLM setup, KVCached configuration               |
+| [development/pf6-guide/](./development/pf6-guide/README.md)                | PatternFly 6 components, styling standards, testing patterns, troubleshooting |
+| [development/frontend-api-client.md](./development/frontend-api-client.md) | Axios setup, API client patterns, error handling                              |
 
 ### Project Management
 
-| Document | Topics Covered |
-|----------|----------------|
-| [CLAUDE.md](../CLAUDE.md) | Project overview, quick start, common commands, active technologies |
-| [CHANGELOG.md](../CHANGELOG.md) | Project change history, feature additions, bug fixes |
-| [specs/quickstart.md](../specs/001-multi-model-platform/quickstart.md) | Developer quickstart guide |
+| Document                                                               | Topics Covered                                                      |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [CLAUDE.md](../CLAUDE.md)                                              | Project overview, quick start, common commands, active technologies |
+| [CHANGELOG.md](../CHANGELOG.md)                                        | Project change history, feature additions, bug fixes                |
+| [specs/quickstart.md](../specs/001-multi-model-platform/quickstart.md) | Developer quickstart guide                                          |
 
 ## Key Concepts
 
 ### Controller API
 
 The **Controller API** manages the lifecycle of model instances:
+
 - **Load models** dynamically without downtime
 - **Unload models** to free GPU memory
 - **Query status** of all running models
@@ -165,11 +170,12 @@ The **Controller API** manages the lifecycle of model instances:
 
 **Base URL:** `http://localhost:3000/api/v1/`
 
-**Authentication:** OAuth 2.0 / OIDC with RBAC
+**Authentication:** OAuth 2.0 with RBAC (`admin`, `admin-readonly` roles)
 
 ### Proxy API
 
 The **Proxy API** provides a unified inference endpoint:
+
 - **OpenAI-compatible** format (drop-in replacement)
 - **Routes requests** to the correct model instance
 - **Streaming support** via Server-Sent Events (SSE)
@@ -182,6 +188,7 @@ The **Proxy API** provides a unified inference endpoint:
 ### KVCached
 
 **KVCached** is a GPU memory sharing tool that enables multiple vLLM instances to coexist on a single GPU:
+
 - **IPC segments** for shared KV cache
 - **Memory limits** enforced per model
 - **Dynamic allocation** based on demand
@@ -217,13 +224,13 @@ See [kvcached/README.md](./kvcached/README.md) for detailed setup instructions.
 
 ## Performance Targets
 
-| Metric | Target | Status |
-|--------|--------|--------|
-| **Proxy Routing Overhead** | <50ms (p95) | 🔴 CRITICAL |
-| **Model Load Time** | <60s (1-3B params) | 🟡 Target |
-| **Model Unload Time** | <30s | 🟡 Target |
-| **Concurrent Models** | 3-5 (24GB GPU) | 🟡 Target |
-| **Request Throughput** | vLLM native + <5% overhead | 🟡 Target |
+| Metric                     | Target                     | Status      |
+| -------------------------- | -------------------------- | ----------- |
+| **Proxy Routing Overhead** | <50ms (p95)                | 🔴 CRITICAL |
+| **Model Load Time**        | <60s (1-3B params)         | 🟡 Target   |
+| **Model Unload Time**      | <30s                       | 🟡 Target   |
+| **Concurrent Models**      | 3-5 (24GB GPU)             | 🟡 Target   |
+| **Request Throughput**     | vLLM native + <5% overhead | 🟡 Target   |
 
 ## FAQ
 
@@ -231,6 +238,7 @@ See [kvcached/README.md](./kvcached/README.md) for detailed setup instructions.
 <summary><strong>Can I use this with non-NVIDIA GPUs?</strong></summary>
 
 No, vLLM and KVCached require NVIDIA GPUs with CUDA support. AMD GPUs (ROCm) are not currently supported.
+
 </details>
 
 <details>
@@ -242,41 +250,61 @@ Yes! The Proxy API is OpenAI-compatible. Just point your OpenAI client to the pr
 from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-needed")
 ```
+
 </details>
 
 <details>
 <summary><strong>How many models can I run simultaneously?</strong></summary>
 
 It depends on your GPU memory. Example on a 24GB GPU:
+
 - 3-5 small models (1-3B params)
 - 2-3 medium models (7B params)
 - 1 large model (13B+ params) + 1-2 small models
 
 Use KVCached to optimize memory sharing.
+
 </details>
 
 <details>
 <summary><strong>Can I deploy this on CPU-only machines?</strong></summary>
 
 No, vLLM requires GPU acceleration. CPU-only inference is not supported.
+
 </details>
 
 <details>
 <summary><strong>Is persistent storage required?</strong></summary>
 
 For the PoC phase, no database is required (in-memory storage). Model files can be stored on PVC, NFS, or object storage (S3).
+
 </details>
 
 <details>
 <summary><strong>How do I enable authentication?</strong></summary>
 
-Set OAuth environment variables:
-- `OAUTH_ENABLED=true`
-- `OAUTH_ISSUER_URL=<your-keycloak-url>`
-- `OAUTH_CLIENT_ID=<client-id>`
-- `OAUTH_CLIENT_SECRET=<client-secret>`
+Set the `AUTH_MODE` environment variable:
 
-See [deployment.md](./deployment.md#configuration) for details.
+**Simple Mode** (username/password):
+
+- `AUTH_MODE=simple`
+- `ADMIN_USERNAME=admin`
+- `ADMIN_PASSWORD=<your-password>`
+- `JWT_SECRET=<your-secret>`
+
+**OAuth Mode** (OpenShift):
+
+- `AUTH_MODE=oauth`
+- `OAUTH_ISSUER_URL=<your-openshift-oauth-url>`
+- `OAUTH_CLIENT_ID=sardeenz`
+- `OAUTH_CLIENT_SECRET=<client-secret>`
+- `K8S_API_URL=<kubernetes-api-url>`
+- `JWT_SECRET=<your-secret>`
+
+Roles are assigned via OpenShift groups: `sardeenz-admins` (full access) and `sardeenz-admins-readonly` (read-only).
+
+See [api-guide.md](./api-guide.md#authentication) and [deployment.md](./deployment.md#configuration) for details.
+
 </details>
 
 ## Contributing
@@ -286,10 +314,11 @@ This project follows the principles defined in [`.specify/memory/constitution.md
 - **Type Safety**: TypeScript strict mode
 - **Performance-First**: <50ms routing overhead
 - **API-First Design**: OpenAPI 3.1 specifications
-- **Security by Design**: OAuth/OIDC + RBAC
+- **Security by Design**: OAuth 2.0 + RBAC
 - **Observability**: Prometheus metrics, structured logging
 
 Before contributing, read:
+
 1. [Architecture](./architecture.md) - System design
 2. [Specifications](../specs/001-multi-model-platform/spec.md) - Feature requirements
 3. [CLAUDE.md](../CLAUDE.md) - Development setup
@@ -302,7 +331,7 @@ Before contributing, read:
 
 ## License
 
-*To be determined*
+_To be determined_
 
 ---
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -27,58 +27,235 @@ Sardeenz provides a unified API on a single port:
 
 ### Base URLs
 
-| Environment | Base URL | Example Endpoints |
-|-------------|----------|-------------------|
-| Development | `http://localhost:3000` | `/api/v1/models`, `/v1/chat/completions` |
-| Production | `https://your-domain.com` | `/api/v1/models`, `/v1/chat/completions` |
+| Environment | Base URL                  | Example Endpoints                        |
+| ----------- | ------------------------- | ---------------------------------------- |
+| Development | `http://localhost:3000`   | `/api/v1/models`, `/v1/chat/completions` |
+| Production  | `https://your-domain.com` | `/api/v1/models`, `/v1/chat/completions` |
 
 ### API Versioning
 
 Both APIs use URL-based versioning:
+
 - Controller: `/api/v1/...`
 - Proxy: `/v1/...` (matches OpenAI API convention)
 
 ## Authentication
 
-### Controller API
+Sardeenz uses a **dual-authentication model** that separates admin access from inference access:
 
-**OAuth 2.0 / OIDC with JWT Bearer Tokens**
+| Auth Type          | Purpose                   | Mechanism                            |
+| ------------------ | ------------------------- | ------------------------------------ |
+| **Admin Auth**     | Controller API, Dashboard | JWT (simple or OAuth)                |
+| **Inference Auth** | Inference endpoints       | Optional API key (OpenAI-compatible) |
+
+### Authentication Modes
+
+Admin authentication is configured via the `AUTH_MODE` environment variable:
+
+| Mode     | Description                | Use Case                                   | Roles                                 |
+| -------- | -------------------------- | ------------------------------------------ | ------------------------------------- |
+| `none`   | Authentication disabled    | Development, testing, trusted environments | All users are admin                   |
+| `simple` | Username/password with JWT | Single-admin deployments                   | Authenticated user gets `admin` role  |
+| `oauth`  | OAuth 2.0 (OpenShift)      | Enterprise deployments with SSO            | Roles from OpenShift group membership |
+
+### Route Categories
+
+| Route Type    | Routes                                                                                                    | Auth When `AUTH_MODE!=none`          |
+| ------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **Public**    | `/api/health/*`, `/api/auth/*`, `/docs/*`, `/metrics`                                                     | None required                        |
+| **Admin**     | `/api/models/*`, `/api/gpu/*`, `/api/memory/*`, `/api/benchmarks/*`, `/api/configurations/*`              | JWT required                         |
+| **Inference** | `/v1/*`, `/api/direct/*`, `/tokenize`, `/detokenize`, `/pooling`, `/classification`, `/score`, `/re-rank` | API key (if `INFERENCE_API_KEY` set) |
+
+### Inference API Key (OpenAI-Compatible)
+
+Inference endpoints can be protected separately from admin endpoints using the `INFERENCE_API_KEY` environment variable:
+
+| `INFERENCE_API_KEY` | Behavior                                                         |
+| ------------------- | ---------------------------------------------------------------- |
+| Not set (empty)     | Inference endpoints are open (no auth required)                  |
+| Set to a value      | Inference endpoints require `Authorization: Bearer <key>` header |
+
+**Example with API key protection:**
 
 ```bash
-# Obtain access token from your identity provider
-TOKEN=$(curl -X POST https://your-idp.com/oauth/token \
-  -d "grant_type=client_credentials" \
-  -d "client_id=your-client-id" \
-  -d "client_secret=your-client-secret" \
-  | jq -r '.access_token')
+# Set inference API key
+export INFERENCE_API_KEY=sk-your-secret-key
+
+# Inference request (requires API key)
+curl -X POST http://localhost:3000/v1/chat/completions \
+  -H "Authorization: Bearer sk-your-secret-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "llama-1b", "messages": [{"role": "user", "content": "Hello!"}]}'
+```
+
+**OpenAI SDK compatibility:**
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:3000/v1",
+    api_key="sk-your-secret-key"  # Your INFERENCE_API_KEY value
+)
+
+response = client.chat.completions.create(
+    model="llama-1b",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+**Frontend Dashboard:** When authenticated via the dashboard, the inference API key is automatically provided to the frontend, allowing inference tests and benchmarks to work seamlessly without manual key entry.
+
+### Public Endpoints (No Auth Required)
+
+These endpoints are always accessible without authentication:
+
+- `/api/health/*` - Health checks
+- `/api/auth/*` - Authentication endpoints
+- `/docs`, `/docs/*` - Swagger documentation
+- `/metrics` - Prometheus metrics
+
+### Mode: None (No Authentication)
+
+When `AUTH_MODE=none`, all endpoints are accessible without authentication. This is the default for development.
+
+```bash
+# No token needed
+curl http://localhost:3000/api/v1/models
+```
+
+### Mode: Simple (Username/Password)
+
+When `AUTH_MODE=simple`, users authenticate with username/password to receive a JWT.
+
+**Required Environment Variables:**
+
+- `ADMIN_USERNAME` - Admin username (default: `admin`)
+- `ADMIN_PASSWORD` - Admin password (required)
+- `JWT_SECRET` - Secret for JWT signing
+
+**Login:**
+
+```bash
+# Authenticate and get token
+TOKEN=$(curl -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "your-password"}' \
+  | jq -r '.token')
 
 # Use token in requests
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:3000/api/v1/models
 ```
 
-### RBAC Roles
+### Mode: OAuth (OpenShift OAuth)
 
-| Role | Permissions |
-|------|-------------|
-| `admin` | Load/unload models, view all data |
-| `admin-readonly` | View models and metrics (read-only) |
+When `AUTH_MODE=oauth`, users authenticate via OpenShift OAuth 2.0.
+
+**Required Environment Variables:**
+
+| Variable              | Description                               |
+| --------------------- | ----------------------------------------- |
+| `OAUTH_ISSUER_URL`    | OpenShift OAuth server URL                |
+| `OAUTH_CLIENT_ID`     | OAuth2 client ID                          |
+| `OAUTH_CLIENT_SECRET` | OAuth2 client secret                      |
+| `K8S_API_URL`         | Kubernetes API URL for fetching user info |
+| `API_BASE_URL`        | Backend URL for callbacks                 |
+| `JWT_SECRET`          | Secret for JWT signing                    |
+
+**OAuth Role Mapping:**
+
+Users must be members of OpenShift groups to access the dashboard:
+
+| OpenShift Group            | Application Role | Access Level            |
+| -------------------------- | ---------------- | ----------------------- |
+| `sardeenz-admins`          | `admin`          | Full read/write access  |
+| `sardeenz-admins-readonly` | `admin-readonly` | Read-only access        |
+| (no matching group)        | (denied)         | Cannot access dashboard |
+
+> **Setup:** For step-by-step instructions on creating OpenShift groups and adding users, see the [Deployment Guide: Authentication and RBAC](./deployment.md#authentication-and-rbac).
+
+> **Access Denied:** Users who successfully authenticate but are not members of either group will see an **Access Denied** page explaining which groups are required and how to request access from their OpenShift administrator. After being added to a group, they can click "Try Again" to re-authenticate.
+
+**Flow:**
+
+1. Frontend redirects to `/api/auth/login`
+2. Backend redirects to OpenShift OAuth authorization URL
+3. User authenticates with OpenShift
+4. Provider redirects to `/api/auth/callback`
+5. Backend exchanges code for access token
+6. Backend fetches user info from K8s API (`/apis/user.openshift.io/v1/users/~`)
+7. Backend maps OpenShift groups to application roles
+8. Backend issues internal JWT
+9. Frontend receives JWT via URL fragment
+
+### Using JWT Tokens
+
+All authenticated requests require the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:3000/api/v1/models
+```
 
 **JWT Claims:**
+
 ```json
 {
   "sub": "user@example.com",
+  "username": "admin",
   "roles": ["admin"],
+  "authMode": "simple",
   "iat": 1234567890,
   "exp": 1234571490
 }
 ```
 
-### Proxy API
+### RBAC Roles
 
-The Proxy API is designed to run behind an API gateway (e.g., OpenShift Router) and assumes authentication is handled at the gateway level.
+Role-based access control is enforced on all API routes when authentication is enabled (`AUTH_MODE` is `simple` or `oauth`).
 
-For development/testing, the proxy may run without authentication.
+| Role             | Description                                 |
+| ---------------- | ------------------------------------------- |
+| `admin`          | Full read/write access to all operations    |
+| `admin-readonly` | Read-only access to view data and run tests |
+
+**Detailed Permissions:**
+
+| Action                                     | `admin` | `admin-readonly` |
+| ------------------------------------------ | :-----: | :--------------: |
+| View models, GPU, memory, configurations   |   ✅    |        ✅        |
+| View logs and SSE events                   |   ✅    |        ✅        |
+| Run inference tests (chat, benchmarks)     |   ✅    |        ✅        |
+| View benchmark results and memory profiles |   ✅    |        ✅        |
+| Load/unload models                         |   ✅    |        ❌        |
+| Save/delete/load configurations            |   ✅    |        ❌        |
+| Create/delete benchmarks                   |   ✅    |        ❌        |
+| Delete memory profiles                     |   ✅    |        ❌        |
+| Modify settings (HF token)                 |   ✅    |        ❌        |
+| View real HF token value                   |   ✅    |   ❌ (masked)    |
+| Kill orphan processes                      |   ✅    |        ❌        |
+
+> **Note:** The `admin-readonly` role cannot see the real HuggingFace token value. The API returns a masked placeholder (`hf_****...`) instead.
+
+**Frontend Visual Hints:**
+
+When authenticated with the `admin-readonly` role, the frontend displays visual indicators:
+
+- User dropdown shows role label (e.g., "admin" or "admin-readonly")
+- Write action buttons are disabled with tooltips explaining the permission requirement
+- Read-only users can still navigate all pages and view data
+
+### Auth API Endpoints
+
+| Endpoint             | Method | Description                     |
+| -------------------- | ------ | ------------------------------- |
+| `/api/auth/info`     | GET    | Returns auth mode configuration |
+| `/api/auth/login`    | POST   | Simple mode login (returns JWT) |
+| `/api/auth/login`    | GET    | OAuth mode redirect to provider |
+| `/api/auth/callback` | GET    | OAuth callback (issues JWT)     |
+| `/api/auth/me`       | GET    | Get current user info           |
+| `/api/auth/logout`   | POST   | Logout (client clears token)    |
 
 ## Controller API
 
@@ -89,6 +266,7 @@ For development/testing, the proxy may run without authentication.
 > **Note:** This endpoint returns immediately with `status: "starting"`. The model loads in the background. Subscribe to the SSE events endpoint (`/api/v1/models/instances/{instance_id}/events`) to monitor loading progress and receive the final `active` or `failed` status.
 
 **Request Body:**
+
 ```json
 {
   "model_path": "meta-llama/Llama-3.2-1B",
@@ -101,15 +279,16 @@ For development/testing, the proxy may run without authentication.
 
 **Request Fields:**
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `model_path` | string | Yes | Model identifier (HuggingFace path or local path) |
-| `max_tokens` | number | No | Maximum context length (default: model's max) |
-| `gpu_ids` | number[] | No | GPU indices to use. If omitted, auto-selects GPU(s) with most free memory |
-| `tensor_parallel_size` | number | No | Number of GPUs for tensor parallelism (default: 1). KVCached is disabled when >1 |
-| `extra_args` | string[] | No | Additional vLLM CLI arguments |
+| Field                  | Type     | Required | Description                                                                      |
+| ---------------------- | -------- | -------- | -------------------------------------------------------------------------------- |
+| `model_path`           | string   | Yes      | Model identifier (HuggingFace path or local path)                                |
+| `max_tokens`           | number   | No       | Maximum context length (default: model's max)                                    |
+| `gpu_ids`              | number[] | No       | GPU indices to use. If omitted, auto-selects GPU(s) with most free memory        |
+| `tensor_parallel_size` | number   | No       | Number of GPUs for tensor parallelism (default: 1). KVCached is disabled when >1 |
+| `extra_args`           | string[] | No       | Additional vLLM CLI arguments                                                    |
 
 **Response (202 Accepted):**
+
 ```json
 {
   "status": "success",
@@ -121,6 +300,7 @@ For development/testing, the proxy may run without authentication.
 ```
 
 **Example (curl):**
+
 ```bash
 curl -X POST http://localhost:3000/api/v1/models/load \
   -H "Authorization: Bearer $TOKEN" \
@@ -132,6 +312,7 @@ curl -X POST http://localhost:3000/api/v1/models/load \
 ```
 
 **Example with tensor parallelism (2 GPUs):**
+
 ```bash
 curl -X POST http://localhost:3000/api/v1/models/load \
   -H "Authorization: Bearer $TOKEN" \
@@ -145,21 +326,22 @@ curl -X POST http://localhost:3000/api/v1/models/load \
 ```
 
 **Example (JavaScript):**
+
 ```javascript
 const response = await fetch('http://localhost:3000/api/v1/models/load', {
   method: 'POST',
   headers: {
-    'Authorization': `Bearer ${token}`,
+    Authorization: `Bearer ${token}`,
     'Content-Type': 'application/json',
   },
   body: JSON.stringify({
     model_path: 'meta-llama/Llama-3.2-1B',
     max_tokens: 4096,
   }),
-});
+})
 
-const result = await response.json();
-console.log('Model loading:', result.instance_id);
+const result = await response.json()
+console.log('Model loading:', result.instance_id)
 ```
 
 ### List Models
@@ -167,6 +349,7 @@ console.log('Model loading:', result.instance_id);
 **Endpoint:** `GET /api/v1/models`
 
 **Response (200 OK):**
+
 ```json
 {
   "models": [
@@ -206,6 +389,7 @@ console.log('Model loading:', result.instance_id);
 ```
 
 **Example (curl):**
+
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:3000/api/v1/models
@@ -216,6 +400,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 **Endpoint:** `GET /api/v1/models/{id}`
 
 **Response (200 OK):**
+
 ```json
 {
   "model": {
@@ -236,8 +421,8 @@ curl -H "Authorization: Bearer $TOKEN" \
       "total_gpu_memory_gib": 1.22,
       "weights_memory_gib": 0.67,
       "cuda_graph_memory_gib": 0.55,
-      "overhead_memory_gib": 0.40,
-      "kv_cache_available_gib": 5.70,
+      "overhead_memory_gib": 0.4,
+      "kv_cache_available_gib": 5.7,
       "kv_cache_per_request_mib": 156.23,
       "max_model_len": 4096
     },
@@ -247,6 +432,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 ```
 
 **Example (curl):**
+
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:3000/api/v1/models/llama-3-2-1b-abc123
@@ -260,22 +446,23 @@ Real-time Server-Sent Events stream for model instance status and logs.
 
 **Query Parameters:**
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `types` | string | all | Comma-separated event types: `log,status,memory,progress,error` |
-| `replay_logs` | string | true | Replay existing buffered logs on connection |
+| Parameter     | Type   | Default | Description                                                     |
+| ------------- | ------ | ------- | --------------------------------------------------------------- |
+| `types`       | string | all     | Comma-separated event types: `log,status,memory,progress,error` |
+| `replay_logs` | string | true    | Replay existing buffered logs on connection                     |
 
 **Event Types:**
 
-| Type | Description |
-|------|-------------|
-| `log` | vLLM process stdout/stderr output |
-| `status` | Model status transitions (starting → active/failed) |
-| `memory` | GPU memory updates |
-| `progress` | Loading progress updates |
-| `error` | Error notifications |
+| Type       | Description                                         |
+| ---------- | --------------------------------------------------- |
+| `log`      | vLLM process stdout/stderr output                   |
+| `status`   | Model status transitions (starting → active/failed) |
+| `memory`   | GPU memory updates                                  |
+| `progress` | Loading progress updates                            |
+| `error`    | Error notifications                                 |
 
 **Response (SSE Stream):**
+
 ```
 event: status
 data: {"id":"evt-123","timestamp":"2025-11-11T10:30:00Z","instanceId":"abc123","eventType":"status","data":{"previousStatus":"starting","currentStatus":"active","message":"Model ready for inference"}}
@@ -285,6 +472,7 @@ data: {"id":"evt-124","timestamp":"2025-11-11T10:30:01Z","instanceId":"abc123","
 ```
 
 **Example (curl):**
+
 ```bash
 curl -N -H "Authorization: Bearer $TOKEN" \
   "http://localhost:3000/api/v1/models/instances/abc123/events?types=status,log"
@@ -298,11 +486,12 @@ Retrieve buffered vLLM process logs for debugging.
 
 **Query Parameters:**
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `lines` | number | 100 | Number of lines to return (1-500) |
+| Parameter | Type   | Default | Description                       |
+| --------- | ------ | ------- | --------------------------------- |
+| `lines`   | number | 100     | Number of lines to return (1-500) |
 
 **Response (200 OK):**
+
 ```json
 {
   "instance_id": "abc123",
@@ -312,6 +501,7 @@ Retrieve buffered vLLM process logs for debugging.
 ```
 
 **Example (curl):**
+
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
   "http://localhost:3000/api/v1/models/instances/abc123/logs?lines=50"
@@ -322,6 +512,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 **Endpoint:** `POST /api/v1/models/{id}/unload`
 
 **Response (202 Accepted):**
+
 ```json
 {
   "id": "llama-3-2-1b-abc123",
@@ -331,6 +522,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 ```
 
 **Example (curl):**
+
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $TOKEN" \
@@ -342,32 +534,34 @@ curl -X POST \
 **Endpoint:** `GET /api/v1/metrics`
 
 **Response (200 OK - Prometheus Format):**
+
 ```
-# HELP vllm_stacker_models_total Total number of model instances
-# TYPE vllm_stacker_models_total gauge
-vllm_stacker_models_total{status="active"} 2
-vllm_stacker_models_total{status="starting"} 0
-vllm_stacker_models_total{status="stopping"} 0
-vllm_stacker_models_total{status="failed"} 0
+# HELP sardeenz_models_total Total number of model instances
+# TYPE sardeenz_models_total gauge
+sardeenz_models_total{status="active"} 2
+sardeenz_models_total{status="starting"} 0
+sardeenz_models_total{status="stopping"} 0
+sardeenz_models_total{status="failed"} 0
 
-# HELP vllm_stacker_gpu_memory_used_bytes GPU memory used by all models
-# TYPE vllm_stacker_gpu_memory_used_bytes gauge
-vllm_stacker_gpu_memory_used_bytes{model_id="llama-3-2-1b-abc123"} 4080218931
-vllm_stacker_gpu_memory_used_bytes{model_id="mistral-7b-def456"} 8589934592
+# HELP sardeenz_gpu_memory_used_bytes GPU memory used by all models
+# TYPE sardeenz_gpu_memory_used_bytes gauge
+sardeenz_gpu_memory_used_bytes{model_id="llama-3-2-1b-abc123"} 4080218931
+sardeenz_gpu_memory_used_bytes{model_id="mistral-7b-def456"} 8589934592
 
-# HELP vllm_stacker_requests_total Total inference requests
-# TYPE vllm_stacker_requests_total counter
-vllm_stacker_requests_total{model_id="llama-3-2-1b-abc123",status="success"} 1523
-vllm_stacker_requests_total{model_id="mistral-7b-def456",status="success"} 892
+# HELP sardeenz_requests_total Total inference requests
+# TYPE sardeenz_requests_total counter
+sardeenz_requests_total{model_id="llama-3-2-1b-abc123",status="success"} 1523
+sardeenz_requests_total{model_id="mistral-7b-def456",status="success"} 892
 
-# HELP vllm_stacker_request_duration_ms Request duration in milliseconds
-# TYPE vllm_stacker_request_duration_ms histogram
-vllm_stacker_request_duration_ms_bucket{model_id="llama-3-2-1b-abc123",le="100"} 234
-vllm_stacker_request_duration_ms_bucket{model_id="llama-3-2-1b-abc123",le="500"} 1421
-vllm_stacker_request_duration_ms_bucket{model_id="llama-3-2-1b-abc123",le="+Inf"} 1523
+# HELP sardeenz_request_duration_ms Request duration in milliseconds
+# TYPE sardeenz_request_duration_ms histogram
+sardeenz_request_duration_ms_bucket{model_id="llama-3-2-1b-abc123",le="100"} 234
+sardeenz_request_duration_ms_bucket{model_id="llama-3-2-1b-abc123",le="500"} 1421
+sardeenz_request_duration_ms_bucket{model_id="llama-3-2-1b-abc123",le="+Inf"} 1523
 ```
 
 **Example (curl):**
+
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:3000/api/v1/metrics
@@ -380,6 +574,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 > **Note:** Health check endpoints (`/api/health`, `/api/health/ready`, `/api/health/live`) have quiet logging enabled. Successful requests (2xx) are logged at debug level only to reduce log noise from frequent polling. Errors (4xx/5xx) are always logged at warn/error levels.
 
 **Response (200 OK):**
+
 ```json
 {
   "status": "healthy",
@@ -390,10 +585,12 @@ curl -H "Authorization: Bearer $TOKEN" \
 ```
 
 **Additional Health Endpoints:**
+
 - `GET /api/health/ready` - Readiness probe (returns `{"status": "ready", "timestamp": "..."}`)
 - `GET /api/health/live` - Liveness probe (returns `{"status": "alive", "timestamp": "..."}`)
 
 **Example (curl):**
+
 ```bash
 curl http://localhost:3000/api/health
 ```
@@ -405,6 +602,7 @@ curl http://localhost:3000/api/health
 Returns GPU and KVCache memory usage with per-model breakdown for visualization (used by the GPU Memory Overview panel in the dashboard).
 
 **Response (200 OK):**
+
 ```json
 {
   "kvcache": {
@@ -447,43 +645,45 @@ Returns GPU and KVCache memory usage with per-model breakdown for visualization 
 
 **Field Descriptions:**
 
-| Field | Description |
-|-------|-------------|
-| `kvcache.total_gb` | Total KVCache pool size (shared across all models) |
-| `kvcache.prealloc_gb` | Pre-allocated but not actively used KVCache memory |
-| `kvcache.used_gb` | Currently active KVCache memory |
-| `kvcache.free_gb` | Available KVCache memory |
-| `gpu.total_gb` | Total GPU memory |
-| `gpu.used_gb` | Used GPU memory (all processes) |
-| `gpu.free_gb` | Free GPU memory |
-| `gpu.utilization_percent` | GPU utilization percentage |
-| `models[].model_path` | Full model path/identifier |
-| `models[].instance_id` | Unique instance identifier (stable across API calls) |
-| `models[].display_name` | Short display name, unique per instance. For duplicate models, includes suffix: "Model", "Model (2)", etc. |
-| `models[].gpu_memory_gb` | Model's GPU footprint (weights + CUDA graphs) |
-| `models[].color` | Hex color for visualization (unique per instance, based on instance_id hash) |
+| Field                     | Description                                                                                                |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `kvcache.total_gb`        | Total KVCache pool size (shared across all models)                                                         |
+| `kvcache.prealloc_gb`     | Pre-allocated but not actively used KVCache memory                                                         |
+| `kvcache.used_gb`         | Currently active KVCache memory                                                                            |
+| `kvcache.free_gb`         | Available KVCache memory                                                                                   |
+| `gpu.total_gb`            | Total GPU memory                                                                                           |
+| `gpu.used_gb`             | Used GPU memory (all processes)                                                                            |
+| `gpu.free_gb`             | Free GPU memory                                                                                            |
+| `gpu.utilization_percent` | GPU utilization percentage                                                                                 |
+| `models[].model_path`     | Full model path/identifier                                                                                 |
+| `models[].instance_id`    | Unique instance identifier (stable across API calls)                                                       |
+| `models[].display_name`   | Short display name, unique per instance. For duplicate models, includes suffix: "Model", "Model (2)", etc. |
+| `models[].gpu_memory_gb`  | Model's GPU footprint (weights + CUDA graphs)                                                              |
+| `models[].color`          | Hex color for visualization (unique per instance, based on instance_id hash)                               |
 
 **Example (curl):**
+
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:3000/api/memory/usage
 ```
 
 **Example (JavaScript):**
+
 ```javascript
 const response = await fetch('http://localhost:3000/api/memory/usage', {
-  headers: { 'Authorization': `Bearer ${token}` },
-});
-const memoryData = await response.json();
+  headers: { Authorization: `Bearer ${token}` },
+})
+const memoryData = await response.json()
 
 // KVCache metrics (shared pool)
-console.log(`KVCache: ${memoryData.kvcache.used_gb}/${memoryData.kvcache.total_gb} GB`);
+console.log(`KVCache: ${memoryData.kvcache.used_gb}/${memoryData.kvcache.total_gb} GB`)
 
 // GPU metrics with per-model breakdown
-console.log(`GPU: ${memoryData.gpu.used_gb}/${memoryData.gpu.total_gb} GB`);
-memoryData.models.forEach(model => {
-  console.log(`  ${model.display_name}: ${model.gpu_memory_gb} GB`);
-});
+console.log(`GPU: ${memoryData.gpu.used_gb}/${memoryData.gpu.total_gb} GB`)
+memoryData.models.forEach((model) => {
+  console.log(`  ${model.display_name}: ${model.gpu_memory_gb} GB`)
+})
 ```
 
 ### Get Multi-GPU Memory Usage
@@ -493,6 +693,7 @@ memoryData.models.forEach(model => {
 Returns per-GPU memory breakdown for multi-GPU systems.
 
 **Response (200 OK):**
+
 ```json
 {
   "gpus": [
@@ -542,6 +743,7 @@ Returns per-GPU memory breakdown for multi-GPU systems.
 Returns all GPUs with availability information and a recommendation for the next model load.
 
 **Response (200 OK):**
+
 ```json
 {
   "gpus": [
@@ -575,6 +777,7 @@ Returns all GPUs with availability information and a recommendation for the next
 ```
 
 **Example (curl):**
+
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:3000/api/gpu/available
@@ -584,6 +787,8 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 The Direct Proxy provides a lightweight, port-based proxy for testing and debugging. It bypasses the model routing layer and forwards requests directly to a specific vLLM instance port.
 
+> **Authentication:** Like the Proxy API, when `INFERENCE_API_KEY` is set, direct proxy endpoints require `Authorization: Bearer <api-key>` header. See [Inference API Key](#inference-api-key-openai-compatible) for details.
+
 ### Forward Request to Port
 
 **Endpoint:** `ALL /api/direct/:port/*`
@@ -591,10 +796,12 @@ The Direct Proxy provides a lightweight, port-based proxy for testing and debugg
 Forwards any request directly to `http://localhost:{port}/{path}`.
 
 **Parameters:**
+
 - `port` - The vLLM instance port (e.g., 5001)
 - `*` - The path to forward (e.g., `v1/chat/completions`)
 
 **Example (curl):**
+
 ```bash
 # Chat completion via direct proxy to port 5001
 curl -X POST http://localhost:3000/api/direct/5001/v1/chat/completions \
@@ -606,10 +813,12 @@ curl -X POST http://localhost:3000/api/direct/5001/v1/chat/completions \
 ```
 
 **Supported Responses:**
+
 - JSON responses are returned directly
 - SSE/streaming responses are piped through
 
 **Use Cases:**
+
 - Testing a specific model instance without model routing
 - Debugging inference issues
 - Bypassing the proxy layer for performance testing
@@ -618,11 +827,14 @@ curl -X POST http://localhost:3000/api/direct/5001/v1/chat/completions \
 
 The Proxy API provides OpenAI-compatible endpoints for inference requests.
 
+> **Authentication:** When `INFERENCE_API_KEY` is set, all proxy endpoints require `Authorization: Bearer <api-key>` header. When not set, endpoints are open. See [Inference API Key](#inference-api-key-openai-compatible) for details.
+
 ### Chat Completions
 
 **Endpoint:** `POST /v1/chat/completions`
 
 **Request Body:**
+
 ```json
 {
   "model": "llama-3-2-1b-abc123",
@@ -643,6 +855,7 @@ The Proxy API provides OpenAI-compatible endpoints for inference requests.
 ```
 
 **Response (200 OK):**
+
 ```json
 {
   "id": "chatcmpl-abc123",
@@ -668,6 +881,7 @@ The Proxy API provides OpenAI-compatible endpoints for inference requests.
 ```
 
 **Example (curl):**
+
 ```bash
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -680,6 +894,7 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 ```
 
 **Example (Python with OpenAI SDK):**
+
 ```python
 from openai import OpenAI
 
@@ -702,17 +917,17 @@ print(response.choices[0].message.content)
 ### Streaming Chat Completions
 
 **Request Body (with streaming):**
+
 ```json
 {
   "model": "llama-3-2-1b-abc123",
-  "messages": [
-    {"role": "user", "content": "Write a short poem about AI."}
-  ],
+  "messages": [{ "role": "user", "content": "Write a short poem about AI." }],
   "stream": true
 }
 ```
 
 **Response (Server-Sent Events):**
+
 ```
 data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1699999999,"model":"llama-3-2-1b-abc123","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
 
@@ -726,6 +941,7 @@ data: [DONE]
 ```
 
 **Example (Python with OpenAI SDK):**
+
 ```python
 from openai import OpenAI
 
@@ -743,6 +959,7 @@ for chunk in stream:
 ```
 
 **Example (JavaScript with fetch):**
+
 ```javascript
 const response = await fetch('http://localhost:8000/v1/chat/completions', {
   method: 'POST',
@@ -752,26 +969,26 @@ const response = await fetch('http://localhost:8000/v1/chat/completions', {
     messages: [{ role: 'user', content: 'Write a short poem about AI.' }],
     stream: true,
   }),
-});
+})
 
-const reader = response.body.getReader();
-const decoder = new TextDecoder();
+const reader = response.body.getReader()
+const decoder = new TextDecoder()
 
 while (true) {
-  const { done, value } = await reader.read();
-  if (done) break;
+  const { done, value } = await reader.read()
+  if (done) break
 
-  const chunk = decoder.decode(value);
-  const lines = chunk.split('\n').filter(line => line.startsWith('data: '));
+  const chunk = decoder.decode(value)
+  const lines = chunk.split('\n').filter((line) => line.startsWith('data: '))
 
   for (const line of lines) {
-    const data = line.replace('data: ', '');
-    if (data === '[DONE]') break;
+    const data = line.replace('data: ', '')
+    if (data === '[DONE]') break
 
-    const parsed = JSON.parse(data);
-    const content = parsed.choices[0]?.delta?.content;
+    const parsed = JSON.parse(data)
+    const content = parsed.choices[0]?.delta?.content
     if (content) {
-      process.stdout.write(content);
+      process.stdout.write(content)
     }
   }
 }
@@ -782,6 +999,7 @@ while (true) {
 **Endpoint:** `POST /v1/completions`
 
 **Request Body:**
+
 ```json
 {
   "model": "llama-3-2-1b-abc123",
@@ -792,6 +1010,7 @@ while (true) {
 ```
 
 **Response (200 OK):**
+
 ```json
 {
   "id": "cmpl-abc123",
@@ -818,6 +1037,7 @@ while (true) {
 ### Controller API Errors
 
 **Model Not Found (404):**
+
 ```json
 {
   "error": {
@@ -829,6 +1049,7 @@ while (true) {
 ```
 
 **Insufficient GPU Memory (400):**
+
 ```json
 {
   "error": {
@@ -840,6 +1061,7 @@ while (true) {
 ```
 
 **Unauthorized (401):**
+
 ```json
 {
   "error": {
@@ -851,6 +1073,7 @@ while (true) {
 ```
 
 **Forbidden (403):**
+
 ```json
 {
   "error": {
@@ -862,6 +1085,7 @@ while (true) {
 ```
 
 **Model Already Exists (409):**
+
 ```json
 {
   "error": {
@@ -875,6 +1099,7 @@ while (true) {
 ### Proxy API Errors
 
 **Invalid Model (400):**
+
 ```json
 {
   "error": {
@@ -887,6 +1112,7 @@ while (true) {
 ```
 
 **Model Not Ready (503):**
+
 ```json
 {
   "error": {
@@ -902,15 +1128,15 @@ while (true) {
 ### Complete Workflow (TypeScript)
 
 ```typescript
-import axios from 'axios';
+import axios from 'axios'
 
-const CONTROLLER_URL = 'http://localhost:3000/api/v1';
-const PROXY_URL = 'http://localhost:8000/v1';
-const AUTH_TOKEN = process.env.AUTH_TOKEN;
+const CONTROLLER_URL = 'http://localhost:3000/api/v1'
+const PROXY_URL = 'http://localhost:8000/v1'
+const AUTH_TOKEN = process.env.AUTH_TOKEN
 
 async function completeWorkflow() {
   // 1. Load a model
-  console.log('Loading model...');
+  console.log('Loading model...')
   const loadResponse = await axios.post(
     `${CONTROLLER_URL}/models/load`,
     {
@@ -922,54 +1148,51 @@ async function completeWorkflow() {
     {
       headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
     }
-  );
+  )
 
-  const modelId = loadResponse.data.id;
-  const instanceId = loadResponse.data.instance_id;
-  console.log(`Model loading started: ${instanceId}`);
+  const modelId = loadResponse.data.id
+  const instanceId = loadResponse.data.instance_id
+  console.log(`Model loading started: ${instanceId}`)
 
   // 2. Wait for model to be ready
   // Option A: Polling (shown below)
   // Option B: Subscribe to SSE at /api/v1/models/instances/{instance_id}/events
-  console.log('Waiting for model to be ready...');
-  let status = 'starting';
+  console.log('Waiting for model to be ready...')
+  let status = 'starting'
   while (status === 'starting') {
-    await new Promise(resolve => setTimeout(resolve, 5000));
-    const statusResponse = await axios.get(
-      `${CONTROLLER_URL}/models/${modelId}`,
-      { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } }
-    );
-    status = statusResponse.data.status;
-    console.log(`Status: ${status}`);
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+    const statusResponse = await axios.get(`${CONTROLLER_URL}/models/${modelId}`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    })
+    status = statusResponse.data.status
+    console.log(`Status: ${status}`)
   }
 
   if (status !== 'active') {
-    throw new Error(`Model failed to start: ${status}`);
+    throw new Error(`Model failed to start: ${status}`)
   }
 
   // 3. Make inference request
-  console.log('Making inference request...');
+  console.log('Making inference request...')
   const inferenceResponse = await axios.post(`${PROXY_URL}/chat/completions`, {
     model: modelId,
-    messages: [
-      { role: 'user', content: 'What is 2+2?' },
-    ],
-  });
+    messages: [{ role: 'user', content: 'What is 2+2?' }],
+  })
 
-  console.log('Response:', inferenceResponse.data.choices[0].message.content);
+  console.log('Response:', inferenceResponse.data.choices[0].message.content)
 
   // 4. Unload model
-  console.log('Unloading model...');
+  console.log('Unloading model...')
   await axios.post(
     `${CONTROLLER_URL}/models/${modelId}/unload`,
     {},
     { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } }
-  );
+  )
 
-  console.log('Workflow complete!');
+  console.log('Workflow complete!')
 }
 
-completeWorkflow().catch(console.error);
+completeWorkflow().catch(console.error)
 ```
 
 ### Python Client Library
@@ -979,7 +1202,7 @@ import requests
 import time
 from typing import Optional
 
-class VLLMStackerClient:
+class SardeenzClient:
     def __init__(self, controller_url: str, proxy_url: str, auth_token: str):
         self.controller_url = controller_url
         self.proxy_url = proxy_url
@@ -1043,7 +1266,7 @@ class VLLMStackerClient:
         response.raise_for_status()
 
 # Usage
-client = VLLMStackerClient(
+client = SardeenzClient(
     controller_url="http://localhost:3000/api/v1",
     proxy_url="http://localhost:8000/v1",
     auth_token="your-token-here",
@@ -1071,6 +1294,7 @@ The Benchmark API allows you to run performance tests on loaded models, measurin
 **Endpoint:** `POST /api/benchmarks`
 
 **Request Body:**
+
 ```json
 {
   "name": "SmolLM Performance Test",
@@ -1092,21 +1316,22 @@ The Benchmark API allows you to run performance tests on loaded models, measurin
 
 **Fields:**
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | No | Human-readable name for the benchmark run |
-| `mode` | string | Yes | `isolated` (run scenarios sequentially) or `contention` (run all simultaneously) |
-| `scenarios` | array | Yes | One or more scenarios to benchmark |
-| `scenarios[].instanceId` | string | Yes | Model instance ID to benchmark |
-| `scenarios[].routingMode` | string | No | `direct` (to vLLM) or `proxy` (through unified endpoint). Default: `direct` |
-| `scenarios[].inputTokens` | number | Yes | Target input token count |
-| `scenarios[].outputTokens` | number | Yes | Max tokens for response |
-| `scenarios[].concurrency` | number | Yes | Number of parallel requests |
-| `scenarios[].warmupRequests` | number | Yes | Unmeasured warmup requests |
-| `scenarios[].totalRequests` | number | Yes | Measured requests |
-| `scenarios[].slaThresholdMs` | number | No | SLA threshold for goodput calculation |
+| Field                        | Type   | Required | Description                                                                      |
+| ---------------------------- | ------ | -------- | -------------------------------------------------------------------------------- |
+| `name`                       | string | No       | Human-readable name for the benchmark run                                        |
+| `mode`                       | string | Yes      | `isolated` (run scenarios sequentially) or `contention` (run all simultaneously) |
+| `scenarios`                  | array  | Yes      | One or more scenarios to benchmark                                               |
+| `scenarios[].instanceId`     | string | Yes      | Model instance ID to benchmark                                                   |
+| `scenarios[].routingMode`    | string | No       | `direct` (to vLLM) or `proxy` (through unified endpoint). Default: `direct`      |
+| `scenarios[].inputTokens`    | number | Yes      | Target input token count                                                         |
+| `scenarios[].outputTokens`   | number | Yes      | Max tokens for response                                                          |
+| `scenarios[].concurrency`    | number | Yes      | Number of parallel requests                                                      |
+| `scenarios[].warmupRequests` | number | Yes      | Unmeasured warmup requests                                                       |
+| `scenarios[].totalRequests`  | number | Yes      | Measured requests                                                                |
+| `scenarios[].slaThresholdMs` | number | No       | SLA threshold for goodput calculation                                            |
 
 **Response (201 Created):**
+
 ```json
 {
   "benchmark": {
@@ -1142,13 +1367,14 @@ The Benchmark API allows you to run performance tests on loaded models, measurin
 
 **Query Parameters:**
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `page` | number | 1 | Page number |
-| `limit` | number | 20 | Results per page (max 100) |
-| `status` | string | all | Filter by status: `pending`, `running`, `completed`, `cancelled`, `failed` |
+| Parameter | Type   | Default | Description                                                                |
+| --------- | ------ | ------- | -------------------------------------------------------------------------- |
+| `page`    | number | 1       | Page number                                                                |
+| `limit`   | number | 20      | Results per page (max 100)                                                 |
+| `status`  | string | all     | Filter by status: `pending`, `running`, `completed`, `cancelled`, `failed` |
 
 **Response (200 OK):**
+
 ```json
 {
   "benchmarks": [
@@ -1180,6 +1406,7 @@ The Benchmark API allows you to run performance tests on loaded models, measurin
 Returns full benchmark details including scenarios and aggregated metrics.
 
 **Response (200 OK):**
+
 ```json
 {
   "benchmark": {
@@ -1242,17 +1469,18 @@ Real-time progress updates via Server-Sent Events.
 
 **Event Types:**
 
-| Event | Description |
-|-------|-------------|
-| `benchmark:started` | Benchmark run has started |
-| `scenario:started` | A scenario has started |
-| `scenario:warmup` | Warmup phase progress |
-| `scenario:progress` | Measured request progress |
-| `scenario:completed` | Scenario finished with metrics |
-| `benchmark:completed` | All scenarios complete |
-| `benchmark:failed` | Benchmark run failed |
+| Event                 | Description                    |
+| --------------------- | ------------------------------ |
+| `benchmark:started`   | Benchmark run has started      |
+| `scenario:started`    | A scenario has started         |
+| `scenario:warmup`     | Warmup phase progress          |
+| `scenario:progress`   | Measured request progress      |
+| `scenario:completed`  | Scenario finished with metrics |
+| `benchmark:completed` | All scenarios complete         |
+| `benchmark:failed`    | Benchmark run failed           |
 
 **Example SSE Event:**
+
 ```
 event: scenario:progress
 data: {"scenario_id":"uuid","completed":10,"total":20,"success_count":10,"error_count":0}
@@ -1262,18 +1490,19 @@ data: {"scenario_id":"uuid","metrics":{"ttft_avg":45.2,"tps_avg":156.8,...}}
 ```
 
 **Example (JavaScript):**
+
 ```javascript
-const eventSource = new EventSource('/api/benchmarks/550e8400-e29b-41d4-a716-446655440000/events');
+const eventSource = new EventSource('/api/benchmarks/550e8400-e29b-41d4-a716-446655440000/events')
 
 eventSource.addEventListener('scenario:progress', (event) => {
-  const data = JSON.parse(event.data);
-  console.log(`Progress: ${data.completed}/${data.total}`);
-});
+  const data = JSON.parse(event.data)
+  console.log(`Progress: ${data.completed}/${data.total}`)
+})
 
 eventSource.addEventListener('benchmark:completed', (event) => {
-  console.log('Benchmark complete!');
-  eventSource.close();
-});
+  console.log('Benchmark complete!')
+  eventSource.close()
+})
 ```
 
 ### Delete a Benchmark Run
@@ -1281,6 +1510,7 @@ eventSource.addEventListener('benchmark:completed', (event) => {
 **Endpoint:** `DELETE /api/benchmarks/{id}`
 
 **Response (200 OK):**
+
 ```json
 {
   "success": true,
@@ -1297,6 +1527,7 @@ The Memory Profile API allows you to save and retrieve GPU memory footprints for
 **Endpoint:** `GET /api/memory/profiles`
 
 **Response (200 OK):**
+
 ```json
 {
   "profiles": [
@@ -1308,8 +1539,8 @@ The Memory Profile API allows you to save and retrieve GPU memory footprints for
       "total_gpu_memory_gib": 1.22,
       "weights_memory_gib": 0.27,
       "cuda_graphs_gib": 0.55,
-      "overhead_memory_gib": 0.40,
-      "kv_cache_available_gib": 5.70,
+      "overhead_memory_gib": 0.4,
+      "kv_cache_available_gib": 5.7,
       "gpu_name": "NVIDIA GeForce RTX 4090",
       "gpu_total_memory_gib": 24.0,
       "created_at": "2025-11-29T12:00:00Z"
@@ -1326,6 +1557,7 @@ The Memory Profile API allows you to save and retrieve GPU memory footprints for
 Create a profile from a running model instance:
 
 **Request Body:**
+
 ```json
 {
   "instanceId": "smollm2-135m-abc123",
@@ -1350,6 +1582,7 @@ Or create manually with explicit values:
 ```
 
 **Response (201 Created):**
+
 ```json
 {
   "profile": {
@@ -1360,8 +1593,8 @@ Or create manually with explicit values:
     "total_gpu_memory_gib": 1.22,
     "weights_memory_gib": 0.27,
     "cuda_graphs_gib": 0.55,
-    "overhead_memory_gib": 0.40,
-    "kv_cache_available_gib": 5.70,
+    "overhead_memory_gib": 0.4,
+    "kv_cache_available_gib": 5.7,
     "gpu_name": "NVIDIA GeForce RTX 4090",
     "gpu_total_memory_gib": 24.0,
     "created_at": "2025-11-29T12:00:00Z"
@@ -1377,13 +1610,14 @@ Find a profile by model configuration (useful before loading a model).
 
 **Query Parameters:**
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `model_path` | string | Yes | Model path to lookup |
-| `max_tokens` | number | Yes | Max tokens configuration |
-| `gpu_name` | string | Yes | GPU name (e.g., "NVIDIA GeForce RTX 4090") |
+| Parameter    | Type   | Required | Description                                |
+| ------------ | ------ | -------- | ------------------------------------------ |
+| `model_path` | string | Yes      | Model path to lookup                       |
+| `max_tokens` | number | Yes      | Max tokens configuration                   |
+| `gpu_name`   | string | Yes      | GPU name (e.g., "NVIDIA GeForce RTX 4090") |
 
 **Example:**
+
 ```bash
 curl "http://localhost:3000/api/memory/profiles/lookup?model_path=HuggingFaceTB/SmolLM2-135M-Instruct&max_tokens=2048&gpu_name=NVIDIA%20GeForce%20RTX%204090"
 ```
@@ -1399,6 +1633,7 @@ curl "http://localhost:3000/api/memory/profiles/lookup?model_path=HuggingFaceTB/
 Check if a model will fit in available GPU memory before loading.
 
 **Request Body:**
+
 ```json
 {
   "modelPath": "HuggingFaceTB/SmolLM2-135M-Instruct",
@@ -1407,6 +1642,7 @@ Check if a model will fit in available GPU memory before loading.
 ```
 
 **Response (200 OK):**
+
 ```json
 {
   "warning_level": "ok",
@@ -1421,18 +1657,19 @@ Check if a model will fit in available GPU memory before loading.
 
 **Warning Levels:**
 
-| Level | Description |
-|-------|-------------|
-| `ok` | Model should fit with comfortable headroom |
+| Level     | Description                                               |
+| --------- | --------------------------------------------------------- |
+| `ok`      | Model should fit with comfortable headroom                |
 | `caution` | Memory is tight, model may succeed but is close to limits |
-| `danger` | Model will not fit in available GPU memory |
-| `info` | No profile found for this configuration |
+| `danger`  | Model will not fit in available GPU memory                |
+| `info`    | No profile found for this configuration                   |
 
 ### Delete a Memory Profile
 
 **Endpoint:** `DELETE /api/memory/profiles/{id}`
 
 **Response (200 OK):**
+
 ```json
 {
   "success": true,
@@ -1449,6 +1686,7 @@ The Configuration API allows you to save and restore model configurations for qu
 **Endpoint:** `GET /api/configurations`
 
 **Response (200 OK):**
+
 ```json
 {
   "configurations": [
@@ -1470,6 +1708,7 @@ The Configuration API allows you to save and restore model configurations for qu
 **Endpoint:** `GET /api/configurations/{id}`
 
 **Response (200 OK):**
+
 ```json
 {
   "configuration": {
@@ -1502,6 +1741,7 @@ The Configuration API allows you to save and restore model configurations for qu
 Saves current running models as a configuration preset.
 
 **Request Body:**
+
 ```json
 {
   "name": "Production Models",
@@ -1510,6 +1750,7 @@ Saves current running models as a configuration preset.
 ```
 
 **Response (201 Created):**
+
 ```json
 {
   "configuration": {
@@ -1530,6 +1771,7 @@ Unloads all current models and loads models from the saved configuration.
 > **Note:** Models sharing GPUs are loaded sequentially to prevent vLLM memory calculation conflicts. Models on disjoint GPUs load in parallel for faster restoration.
 
 **Response (202 Accepted):**
+
 ```json
 {
   "status": "started",
@@ -1544,6 +1786,7 @@ Unloads all current models and loads models from the saved configuration.
 **Endpoint:** `DELETE /api/configurations/{id}`
 
 **Response (200 OK):**
+
 ```json
 {
   "success": true,
@@ -1554,6 +1797,7 @@ Unloads all current models and loads models from the saved configuration.
 ---
 
 **See Also:**
+
 - [Architecture](./architecture.md) - System architecture details
 - [Deployment Guide](./deployment.md) - Container and OpenShift deployment
 - [OpenAPI Specification](../specs/001-multi-model-platform/contracts/) - Full API schema (when available)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ Sardeenz is a multi-model management platform designed to:
 │              (React + PatternFly 6 UI)                      │
 │                  (served on Port 3000)                      │
 └────────────────┬────────────────────────────────────────────┘
-                 │ HTTPS (OAuth/OIDC)
+                 │ HTTPS (OAuth 2.0)
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
 │              Fastify Backend (Port 3000)                    │
@@ -75,7 +75,7 @@ Sardeenz is a multi-model management platform designed to:
 | **Language** | TypeScript | 5.7+ | Type-safe development (strict mode) |
 | **Framework** | Fastify | 5.1+ | High-performance HTTP server |
 | **Database** | SQLite | 3.x | Benchmark/profile persistence (better-sqlite3) |
-| **Auth** | @fastify/oauth2 | Latest | OAuth 2.0 / OIDC integration |
+| **Auth** | @fastify/jwt | Latest | JWT-based OAuth 2.0 integration |
 | **Metrics** | fastify-metrics | Latest | Prometheus-format metrics |
 | **API Docs** | @fastify/swagger | Latest | OpenAPI 3.1 specification |
 | **Process Mgmt** | child_process | Built-in | vLLM subprocess management |
@@ -164,7 +164,7 @@ sardeenz/
 - `GET /api/memory/profiles/{id}` - Get a specific profile
 - `DELETE /api/memory/profiles/{id}` - Delete a profile
 
-**Authentication:** OAuth 2.0 / OIDC with RBAC
+**Authentication:** OAuth 2.0 with RBAC
 - `admin` role: Full control (load/unload)
 - `admin-readonly` role: Read-only access
 
@@ -492,8 +492,8 @@ For detailed KVCached documentation, see [`kvcached/README.md`](./kvcached/READM
 
 ### Authentication
 
-**Controller API:** OAuth 2.0 / OIDC with JWT tokens
-- Keycloak / Auth0 / Okta compatible
+**Controller API:** OAuth 2.0 with JWT tokens
+- OpenShift OAuth compatible
 - RBAC roles encoded in JWT claims
 
 **Proxy API:** Assumes gateway-level authentication
@@ -563,7 +563,7 @@ This architecture follows the principles defined in [`.specify/memory/constituti
 1. **Type Safety & Monorepo**: TypeScript strict mode, workspace structure
 2. **Performance-First**: <50ms routing, streaming support, connection pooling
 3. **API-First Design**: OpenAPI 3.1 specs, URL versioning
-4. **Security by Design**: OAuth/OIDC + RBAC from day 1
+4. **Security by Design**: OAuth 2.0 + RBAC from day 1
 5. **Container-Native**: Docker-first development, GPU-aware containers
 6. **Observability**: Prometheus metrics, structured logging, health endpoints
 7. **Simplicity & Pragmatism**: YAGNI principle, integration tests mandatory

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -15,6 +15,7 @@ This document provides detailed backend architecture specifications for the sard
 ## Overview
 
 The backend is a Fastify server providing:
+
 - **Controller API**: Model lifecycle management, GPU selection, benchmarking
 - **Unified Proxy**: OpenAI-compatible inference routing with <50ms overhead target
 - **SSE Events**: Real-time status updates during model operations
@@ -63,13 +64,13 @@ Singleton for SSE event distribution:
 
 Intelligent extraction of meaningful errors from vLLM output:
 
-| Error Pattern | Description |
-|---------------|-------------|
-| CUDA OOM | Memory allocation failures with details |
-| Model not found | Missing model paths or files |
-| Port conflict | Address already in use |
-| CUDA/PyTorch mismatch | Version compatibility issues |
-| Generic exception | Python traceback extraction |
+| Error Pattern         | Description                             |
+| --------------------- | --------------------------------------- |
+| CUDA OOM              | Memory allocation failures with details |
+| Model not found       | Missing model paths or files            |
+| Port conflict         | Address already in use                  |
+| CUDA/PyTorch mismatch | Version compatibility issues            |
+| Generic exception     | Python traceback extraction             |
 
 Falls back to last stderr lines with exit code if no pattern matches.
 
@@ -79,22 +80,22 @@ Parses vLLM process logs to extract memory metrics and process information after
 
 **Memory Metrics Patterns:**
 
-| Log Pattern | Extracted Field |
-|-------------|-----------------|
-| `Model loading took X.XX GiB` | `weightsMemoryGiB` |
-| `Graph capturing finished...took X.XX GiB` | `cudaGraphMemoryGiB` |
-| `Available KV cache memory: X.XX GiB` | `kvCacheAvailableGiB` |
-| `GPU KV cache size: N tokens` | Used for per-request calculation |
-| `Using max model len N` | `maxModelLen` |
+| Log Pattern                                | Extracted Field                  |
+| ------------------------------------------ | -------------------------------- |
+| `Model loading took X.XX GiB`              | `weightsMemoryGiB`               |
+| `Graph capturing finished...took X.XX GiB` | `cudaGraphMemoryGiB`             |
+| `Available KV cache memory: X.XX GiB`      | `kvCacheAvailableGiB`            |
+| `GPU KV cache size: N tokens`              | Used for per-request calculation |
+| `Using max model len N`                    | `maxModelLen`                    |
 
 The `kvCachePerRequestMiB` is calculated as: `(kvCacheAvailableGiB * 1024) / totalTokens * maxModelLen`
 
 **Process ID Patterns:**
 
-| Log Pattern | Extracted Field | Description |
-|-------------|-----------------|-------------|
+| Log Pattern            | Extracted Field | Description                                         |
+| ---------------------- | --------------- | --------------------------------------------------- |
 | `EngineCore_DP0 pid=N` | `engineCorePid` | The vLLM EngineCore process that allocates GPU VRAM |
-| `APIServer pid=N` | `processId` | The main API server process (from spawn) |
+| `APIServer pid=N`      | `processId`     | The main API server process (from spawn)            |
 
 Metrics are parsed once when the model transitions to `active` status and stored in the `ModelInstance` fields. Returns `null` if critical metrics cannot be parsed.
 
@@ -137,6 +138,22 @@ Request routing for inference proxy:
 - **Model lookup**: Resolves model name to running instance
 - **Round-robin**: Load balances across multiple instances of same model
 - **Metrics tracking**: Records request latency and counts
+
+### Inference Auth Plugin (`src/plugins/inference-auth.ts`)
+
+Separate authentication for inference endpoints:
+
+- **Dual-auth model**: Inference endpoints use API key auth, not JWT
+- **Optional protection**: When `INFERENCE_API_KEY` is empty, inference endpoints are open
+- **OpenAI-compatible**: Uses `Authorization: Bearer <key>` header format
+- **Route detection**: `isInferenceRoute()` helper identifies inference endpoints (`/v1/*`, `/api/direct/*`, etc.)
+- **Frontend integration**: API key passed to frontend after admin login for seamless testing
+
+**Protected Routes:**
+
+- `/v1/*` - OpenAI-compatible endpoints
+- `/api/direct/:port/*` - Direct port-based proxy
+- `/tokenize`, `/detokenize`, `/pooling`, `/classification`, `/score`, `/re-rank`
 
 ### ModelConfigurationStore (`src/stores/model-configuration-store.ts`)
 
@@ -271,7 +288,7 @@ The backend implements quiet logging to reduce noise from frequently-polled endp
 
 ```typescript
 interface FastifyContextConfig {
-  logRequests?: boolean  // false = quiet mode
+  logRequests?: boolean // false = quiet mode
 }
 ```
 

--- a/docs/architecture/frontend-architecture.md
+++ b/docs/architecture/frontend-architecture.md
@@ -29,7 +29,7 @@ The sardeenz frontend is a React-based admin dashboard that enables operators to
 - **Type-safe**: TypeScript strict mode throughout
 - **Accessibility**: WCAG 2.1 AA compliance
 - **Performance**: <3s initial load, <200ms interactions
-- **Security**: OAuth/OIDC with role-based access control
+- **Security**: OAuth 2.0 with role-based access control
 
 ## Technology Stack
 
@@ -290,7 +290,7 @@ function App() {
 
 ## Authentication Flow
 
-### OAuth/OIDC Integration
+### OAuth 2.0 Integration
 
 ```
 ┌─────────┐                ┌──────────┐                ┌──────────┐

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,6 +8,7 @@ This guide covers container building and deployment to OpenShift/Kubernetes.
 - [Container Build](#container-build)
 - [Local Development](#local-development)
 - [OpenShift Deployment](#openshift-deployment)
+- [Authentication and RBAC](#authentication-and-rbac)
 - [Configuration](#configuration)
 - [Health Checks](#health-checks)
 - [Monitoring](#monitoring)
@@ -17,22 +18,22 @@ This guide covers container building and deployment to OpenShift/Kubernetes.
 
 ### Hardware Requirements
 
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| **CPU** | 8 cores | 16+ cores |
-| **RAM** | 16 GB | 32+ GB |
-| **GPU** | NVIDIA with 8GB VRAM | 24GB+ VRAM (A10, A100, H100) |
-| **Storage** | 50 GB | 100+ GB SSD |
+| Component   | Minimum              | Recommended                  |
+| ----------- | -------------------- | ---------------------------- |
+| **CPU**     | 8 cores              | 16+ cores                    |
+| **RAM**     | 16 GB                | 32+ GB                       |
+| **GPU**     | NVIDIA with 8GB VRAM | 24GB+ VRAM (A10, A100, H100) |
+| **Storage** | 50 GB                | 100+ GB SSD                  |
 
 ### Software Requirements
 
-| Software | Version | Purpose |
-|----------|---------|---------|
-| **Docker** | 24.x+ | Container runtime |
+| Software                     | Version | Purpose                  |
+| ---------------------------- | ------- | ------------------------ |
+| **Docker**                   | 24.x+   | Container runtime        |
 | **NVIDIA Container Toolkit** | 1.14.x+ | GPU access in containers |
-| **CUDA** | 12.x | GPU compute |
-| **OpenShift** (optional) | 4.12+ | Production orchestration |
-| **kubectl** (optional) | 1.28+ | Kubernetes CLI |
+| **CUDA**                     | 12.x    | GPU compute              |
+| **OpenShift** (optional)     | 4.12+   | Production orchestration |
+| **kubectl** (optional)       | 1.28+   | Kubernetes CLI           |
 
 ### GPU Node Setup
 
@@ -66,6 +67,7 @@ docker run --rm --gpus all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi
 ### Dockerfile Structure
 
 The unified container image includes:
+
 - **Base:** `quay.io/vllm/vllm-cuda:0.11.0` (CUDA 12.x + Python 3.12 + vLLM)
 - **Node.js 22.x** (added layer)
 - **Backend** (Fastify TypeScript app)
@@ -96,7 +98,7 @@ docker build \
 
 ### Multi-Stage Build Example
 
-*Note: This is a conceptual Dockerfile structure. Actual implementation may vary.*
+_Note: This is a conceptual Dockerfile structure. Actual implementation may vary._
 
 ```dockerfile
 # Stage 1: Build frontend
@@ -162,20 +164,20 @@ CMD ["node", "backend/index.js"]
 version: '3.8'
 
 services:
-  vllm-stacker:
+  sardeenz:
     image: sardeenz:latest
     ports:
-      - "3000:3000"  # Unified API (Controller + Proxy + Frontend)
+      - '3000:3000' # Unified API (Controller + Proxy + Frontend)
     environment:
       - NODE_ENV=development
       - ENABLE_KVCACHED=true
       - KVCACHED_AUTOPATCH=1
       - LOG_LEVEL=debug
       - HF_HOME=/opt/app-root/models
-      - OAUTH_ENABLED=false  # Disable auth for local dev
+      - AUTH_MODE=none # Disable auth for local dev
     volumes:
-      - ./models:/opt/app-root/models  # Mount local models directory for HF cache
-      - /tmp/kvcached:/tmp/kvcached  # KVCached IPC directory
+      - ./models:/opt/app-root/models # Mount local models directory for HF cache
+      - /tmp/kvcached:/tmp/kvcached # KVCached IPC directory
     deploy:
       resources:
         reservations:
@@ -184,7 +186,7 @@ services:
               count: 1
               capabilities: [gpu]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:3000/api/health']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -206,7 +208,7 @@ docker compose down
 
 ```bash
 docker run -d \
-  --name vllm-stacker \
+  --name sardeenz \
   --gpus all \
   -p 3000:3000 \
   -e ENABLE_KVCACHED=true \
@@ -231,7 +233,7 @@ docker run -d \
 **1. Create Namespace:**
 
 ```bash
-oc new-project vllm-stacker
+oc new-project sardeenz
 ```
 
 **2. Create Deployment:**
@@ -242,112 +244,112 @@ oc new-project vllm-stacker
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-stacker
-  namespace: vllm-stacker
+  name: sardeenz
+  namespace: sardeenz
   labels:
-    app: vllm-stacker
+    app: sardeenz
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: vllm-stacker
+      app: sardeenz
   template:
     metadata:
       labels:
-        app: vllm-stacker
+        app: sardeenz
     spec:
       containers:
-      - name: vllm-stacker
-        image: quay.io/your-org/sardeenz:latest
-        ports:
-        - containerPort: 3000
-          name: http
-          protocol: TCP
-        env:
-        - name: NODE_ENV
-          value: "production"
-        - name: ENABLE_KVCACHED
-          value: "true"
-        - name: KVCACHED_AUTOPATCH
-          value: "1"
-        - name: HF_HOME
-          value: "/opt/app-root/models"
-        - name: SARDEENZ_DB_PATH
-          value: "/opt/app-root/src/data/sardeenz.db"
-        - name: HF_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: hf-token
-              key: token
-              optional: true
-        - name: LOG_LEVEL
-          value: "info"
-        - name: OAUTH_ISSUER_URL
-          valueFrom:
-            secretKeyRef:
-              name: oauth-config
-              key: issuer-url
-        - name: OAUTH_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: oauth-config
-              key: client-id
-        - name: OAUTH_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: oauth-config
-              key: client-secret
-        resources:
-          requests:
-            memory: "16Gi"
-            cpu: "4"
-            nvidia.com/gpu: "1"
-          limits:
-            memory: "32Gi"
-            cpu: "8"
-            nvidia.com/gpu: "1"
-        volumeMounts:
-        - name: model-cache
-          mountPath: /opt/app-root/models
-        - name: app-data
-          mountPath: /opt/app-root/src
-        - name: kvcached-ipc
-          mountPath: /tmp/kvcached
-        livenessProbe:
-          httpGet:
-            path: /api/health/live
-            port: 3000
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          timeoutSeconds: 10
-          failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /api/health/ready
-            port: 3000
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
+        - name: sardeenz
+          image: quay.io/your-org/sardeenz:latest
+          ports:
+            - containerPort: 3000
+              name: http
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: 'production'
+            - name: ENABLE_KVCACHED
+              value: 'true'
+            - name: KVCACHED_AUTOPATCH
+              value: '1'
+            - name: HF_HOME
+              value: '/opt/app-root/models'
+            - name: SARDEENZ_DB_PATH
+              value: '/opt/app-root/src/data/sardeenz.db'
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: token
+                  optional: true
+            - name: LOG_LEVEL
+              value: 'info'
+            - name: OAUTH_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: oauth-config
+                  key: issuer-url
+            - name: OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: oauth-config
+                  key: client-id
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: oauth-config
+                  key: client-secret
+          resources:
+            requests:
+              memory: '16Gi'
+              cpu: '4'
+              nvidia.com/gpu: '1'
+            limits:
+              memory: '32Gi'
+              cpu: '8'
+              nvidia.com/gpu: '1'
+          volumeMounts:
+            - name: model-cache
+              mountPath: /opt/app-root/models
+            - name: app-data
+              mountPath: /opt/app-root/src
+            - name: kvcached-ipc
+              mountPath: /tmp/kvcached
+          livenessProbe:
+            httpGet:
+              path: /api/health/live
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health/ready
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
-      - name: model-cache
-        persistentVolumeClaim:
-          claimName: model-cache-pvc
-      - name: app-data
-        persistentVolumeClaim:
-          claimName: sardeenz-app-data
-      - name: kvcached-ipc
-        emptyDir:
-          medium: Memory
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache-pvc
+        - name: app-data
+          persistentVolumeClaim:
+            claimName: sardeenz-app-data
+        - name: kvcached-ipc
+          emptyDir:
+            medium: Memory
       securityContext:
         fsGroup: 0
         runAsNonRoot: true
       nodeSelector:
-        nvidia.com/gpu.present: "true"
+        nvidia.com/gpu.present: 'true'
       tolerations:
-      - key: nvidia.com/gpu
-        operator: Exists
-        effect: NoSchedule
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
 ```
 
 **3. Create Service:**
@@ -358,16 +360,16 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: vllm-stacker
-  namespace: vllm-stacker
+  name: sardeenz
+  namespace: sardeenz
 spec:
   selector:
-    app: vllm-stacker
+    app: sardeenz
   ports:
-  - name: http
-    port: 3000
-    targetPort: 3000
-    protocol: TCP
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP
   type: ClusterIP
 ```
 
@@ -379,13 +381,13 @@ spec:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: vllm-stacker
-  namespace: vllm-stacker
+  name: sardeenz
+  namespace: sardeenz
 spec:
-  host: vllm-stacker.apps.your-cluster.com
+  host: sardeenz.apps.your-cluster.com
   to:
     kind: Service
-    name: vllm-stacker
+    name: sardeenz
   port:
     targetPort: http
   tls:
@@ -396,6 +398,7 @@ spec:
 **5. Create PersistentVolumeClaims:**
 
 Two PVCs are required:
+
 - **Model Cache PVC** (`model-cache-pvc`): Stores downloaded HuggingFace models
 - **App Data PVC** (`sardeenz-app-data`): Stores SQLite database and other persistent app data
 
@@ -408,10 +411,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: model-cache-pvc
-  namespace: vllm-stacker
+  namespace: sardeenz
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 100Gi
@@ -429,13 +432,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: sardeenz-app-data
-  namespace: vllm-stacker
+  namespace: sardeenz
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi  # Small - just for SQLite database
+      storage: 1Gi # Small - just for SQLite database
 ```
 
 > **Note:** 1Gi is sufficient for the SQLite database which stores benchmark results and memory profiles.
@@ -446,14 +449,14 @@ spec:
 # HuggingFace token (optional, for gated models like Llama, Mistral)
 oc create secret generic hf-token \
   --from-literal=token=hf_your_token_here \
-  -n vllm-stacker
+  -n sardeenz
 
 # OAuth configuration (optional)
 oc create secret generic oauth-config \
   --from-literal=issuer-url=https://your-keycloak.com/auth/realms/vllm \
-  --from-literal=client-id=vllm-stacker \
+  --from-literal=client-id=sardeenz \
   --from-literal=client-secret=your-secret-here \
-  -n vllm-stacker
+  -n sardeenz
 ```
 
 **7. Deploy:**
@@ -466,70 +469,196 @@ oc apply -f service.yaml
 oc apply -f route.yaml
 
 # Check deployment status
-oc get pods -n vllm-stacker -w
+oc get pods -n sardeenz -w
 
 # View logs
-oc logs -f deployment/vllm-stacker -n vllm-stacker
+oc logs -f deployment/sardeenz -n sardeenz
 ```
 
 ### Scaling Considerations
 
 **Single Pod Deployment (Current Design):**
+
 - One pod manages all model instances
 - Stateless design (no shared state between pods)
 - Scale by deploying multiple independent instances
 
 **Future: Multi-Pod Deployment:**
+
 - Shared model registry (e.g., Redis, PostgreSQL)
 - Sticky sessions for proxy routing
 - Distributed model scheduling
+
+## Authentication and RBAC
+
+Sardeenz supports three authentication modes for the admin dashboard:
+
+| Mode     | Use Case                       | Configuration                              |
+| -------- | ------------------------------ | ------------------------------------------ |
+| `none`   | Development, testing           | No auth required                           |
+| `simple` | Single-admin deployments       | Username/password with JWT                 |
+| `oauth`  | Enterprise with OpenShift SSO  | OpenShift OAuth 2.0 with group-based RBAC  |
+
+### OpenShift OAuth Setup
+
+For production deployments, OAuth mode integrates with OpenShift's authentication system and uses group membership for role-based access control.
+
+#### 1. Create OpenShift Groups
+
+Users must belong to specific OpenShift groups to access the dashboard:
+
+| Group                      | Role             | Access Level            |
+| -------------------------- | ---------------- | ----------------------- |
+| `sardeenz-admins`          | `admin`          | Full read/write access  |
+| `sardeenz-admins-readonly` | `admin-readonly` | Read-only access        |
+
+**Create the groups:**
+
+```bash
+# Create admin group (full access)
+oc adm groups new sardeenz-admins
+
+# Create read-only group
+oc adm groups new sardeenz-admins-readonly
+```
+
+#### 2. Add Users to Groups
+
+```bash
+# Add users to admin group
+oc adm groups add-users sardeenz-admins user1@example.com user2@example.com
+
+# Add users to read-only group
+oc adm groups add-users sardeenz-admins-readonly readonly-user@example.com
+
+# Verify group membership
+oc get group sardeenz-admins -o yaml
+oc get group sardeenz-admins-readonly -o yaml
+```
+
+#### 3. Create OAuth Client
+
+Register Sardeenz as an OAuth client with OpenShift:
+
+**`oauth-client.yaml`:**
+
+```yaml
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: sardeenz
+grantMethod: auto
+redirectURIs:
+  - https://sardeenz.apps.your-cluster.com/api/auth/callback
+secret: your-oauth-client-secret
+```
+
+```bash
+oc apply -f oauth-client.yaml
+```
+
+#### 4. Configure Environment Variables
+
+```bash
+# Create OAuth secret
+oc create secret generic oauth-config \
+  --from-literal=issuer-url=https://oauth-openshift.apps.your-cluster.com \
+  --from-literal=client-id=sardeenz \
+  --from-literal=client-secret=your-oauth-client-secret \
+  -n sardeenz
+
+# Create JWT secret
+oc create secret generic jwt-config \
+  --from-literal=secret=$(openssl rand -base64 32) \
+  -n sardeenz
+```
+
+Add to deployment (see example in OpenShift Deployment section above).
+
+### Access Denied Handling
+
+When a user authenticates via OAuth but is not a member of either `sardeenz-admins` or `sardeenz-admins-readonly`:
+
+1. **Authentication succeeds** - User is verified by OpenShift
+2. **Authorization fails** - User lacks required group membership
+3. **Access Denied page** - User is redirected to an informative error page
+
+The Access Denied page explains:
+
+- The user is not in any authorized groups
+- Which groups are required (`sardeenz-admins` or `sardeenz-admins-readonly`)
+- Instructions to contact an OpenShift administrator
+
+**To grant access:** An OpenShift cluster administrator must add the user to one of the authorized groups:
+
+```bash
+# Grant full admin access
+oc adm groups add-users sardeenz-admins user@example.com
+
+# Grant read-only access
+oc adm groups add-users sardeenz-admins-readonly user@example.com
+```
+
+After being added to a group, the user can click "Try Again" on the Access Denied page to re-authenticate.
+
+### RBAC Permissions
+
+For detailed permissions by role, see [API Guide: RBAC Roles](./api-guide.md#rbac-roles).
 
 ## Configuration
 
 ### Environment Variables
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `NODE_ENV` | No | `development` | Environment mode (`development`, `production`) |
-| `PORT` | No | `3000` | Unified API port (Controller + Proxy + Frontend) |
-| `HF_HOME` | Yes | - | HuggingFace cache directory for model downloads (e.g., `/opt/app-root/models`) |
-| `HF_TOKEN` | No | - | HuggingFace token for accessing gated models (e.g., Llama, Mistral) |
-| `SARDEENZ_DB_PATH` | No | `data/sardeenz.db` | SQLite database file path for persistent storage (e.g., `/opt/app-root/src/data/sardeenz.db`) |
-| `ENABLE_KVCACHED` | Yes | `true` | Enable KVCached memory sharing |
-| `KVCACHED_AUTOPATCH` | No | `1` | Auto-patch vLLM for KVCached |
-| `LOG_LEVEL` | No | `info` | Logging level (`debug`, `info`, `warn`, `error`) |
-| `OAUTH_ENABLED` | No | `true` | Enable OAuth authentication |
-| `OAUTH_ISSUER_URL` | If OAuth enabled | - | OIDC issuer URL |
-| `OAUTH_CLIENT_ID` | If OAuth enabled | - | OAuth client ID |
-| `OAUTH_CLIENT_SECRET` | If OAuth enabled | - | OAuth client secret |
-| `PROMETHEUS_ENABLED` | No | `true` | Enable Prometheus metrics |
-| `MAX_MODELS` | No | `10` | Maximum concurrent models |
-| `GPU_MEMORY_RESERVE` | No | `2.0` | GPU memory reserved for CUDA (GB) |
+| Variable               | Required            | Default            | Description                                                                                                                      |
+| ---------------------- | ------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `NODE_ENV`             | No                  | `development`      | Environment mode (`development`, `production`)                                                                                   |
+| `PORT`                 | No                  | `3000`             | Unified API port (Controller + Proxy + Frontend)                                                                                 |
+| `HF_HOME`              | Yes                 | -                  | HuggingFace cache directory for model downloads (e.g., `/opt/app-root/models`)                                                   |
+| `HF_TOKEN`             | No                  | -                  | HuggingFace token for accessing gated models (e.g., Llama, Mistral)                                                              |
+| `SARDEENZ_DB_PATH`     | No                  | `data/sardeenz.db` | SQLite database file path for persistent storage (e.g., `/opt/app-root/src/data/sardeenz.db`)                                    |
+| `ENABLE_KVCACHED`      | Yes                 | `true`             | Enable KVCached memory sharing                                                                                                   |
+| `KVCACHED_AUTOPATCH`   | No                  | `1`                | Auto-patch vLLM for KVCached                                                                                                     |
+| `LOG_LEVEL`            | No                  | `info`             | Logging level (`debug`, `info`, `warn`, `error`)                                                                                 |
+| `AUTH_MODE`            | No                  | `none`             | Authentication mode: `none` (disabled), `simple` (username/password), `oauth` (OAuth 2.0)                                        |
+| `ADMIN_USERNAME`       | No                  | `admin`            | Username for simple auth mode                                                                                                    |
+| `ADMIN_PASSWORD`       | If AUTH_MODE=simple | -                  | Password for simple auth mode                                                                                                    |
+| `JWT_SECRET`           | If AUTH_MODE!=none  | -                  | Secret for JWT token signing (use strong random value in production)                                                             |
+| `JWT_EXPIRATION_HOURS` | No                  | `8`                | JWT token expiration time in hours                                                                                               |
+| `OAUTH_ISSUER_URL`     | If AUTH_MODE=oauth  | -                  | OAuth issuer URL (e.g., OpenShift OAuth server URL)                                                                              |
+| `K8S_API_URL`          | If AUTH_MODE=oauth  | -                  | Kubernetes API URL for fetching user info                                                                                        |
+| `OAUTH_CLIENT_ID`      | If AUTH_MODE=oauth  | `sardeenz`         | OAuth2 client ID                                                                                                                 |
+| `OAUTH_CLIENT_SECRET`  | If AUTH_MODE=oauth  | -                  | OAuth2 client secret                                                                                                             |
+| `API_BASE_URL`         | If AUTH_MODE=oauth  | -                  | Base URL for OAuth callbacks (e.g., `https://your-domain.com`)                                                                   |
+| `INFERENCE_API_KEY`    | No                  | -                  | API key for inference endpoints. When set, `/v1/*` and `/api/direct/*` require `Authorization: Bearer <key>`. OpenAI-compatible. |
+| `PROMETHEUS_ENABLED`   | No                  | `true`             | Enable Prometheus metrics                                                                                                        |
+| `MAX_MODELS`           | No                  | `10`               | Maximum concurrent models                                                                                                        |
+| `GPU_MEMORY_RESERVE`   | No                  | `2.0`              | GPU memory reserved for CUDA (GB)                                                                                                |
 
 ### Configuration File (Future)
 
-*Note: Configuration file support is planned for future releases.*
+_Note: Configuration file support is planned for future releases._
 
 **`config.yaml`:**
 
 ```yaml
 server:
-  port: 3000  # Unified API port
-  routingOverheadTarget: 50  # ms (p95) for proxy routing
+  port: 3000 # Unified API port
+  routingOverheadTarget: 50 # ms (p95) for proxy routing
 
 auth:
   enabled: true
-  provider: oidc
-  issuerUrl: https://your-keycloak.com/auth/realms/vllm
-  clientId: vllm-stacker
+  provider: oauth
+  issuerUrl: https://oauth-openshift.apps.your-cluster.com
+  k8sApiUrl: https://api.your-cluster.com:6443
+  clientId: sardeenz
 
 gpu:
-  memoryReserve: 2.0  # GB
+  memoryReserve: 2.0 # GB
   maxModels: 5
 
 models:
   path: /models
-  preloadOnStartup: []  # Model IDs to preload
+  preloadOnStartup: [] # Model IDs to preload
 
 logging:
   level: info
@@ -558,6 +687,7 @@ livenessProbe:
 ```
 
 **Response (Healthy):**
+
 ```json
 {
   "status": "alive",
@@ -581,6 +711,7 @@ readinessProbe:
 ```
 
 **Response (Ready):**
+
 ```json
 {
   "status": "ready",
@@ -597,10 +728,11 @@ readinessProbe:
 Metrics are exposed at `http://localhost:3000/api/v1/metrics` in Prometheus format.
 
 **Key Metrics:**
-- `vllm_stacker_models_total{status}` - Total models by status
-- `vllm_stacker_gpu_memory_used_bytes{model_id}` - GPU memory per model
-- `vllm_stacker_requests_total{model_id,status}` - Request counts
-- `vllm_stacker_request_duration_ms{model_id}` - Request latency histogram
+
+- `sardeenz_models_total{status}` - Total models by status
+- `sardeenz_gpu_memory_used_bytes{model_id}` - GPU memory per model
+- `sardeenz_requests_total{model_id,status}` - Request counts
+- `sardeenz_request_duration_ms{model_id}` - Request latency histogram
 
 **ServiceMonitor (OpenShift):**
 
@@ -608,16 +740,16 @@ Metrics are exposed at `http://localhost:3000/api/v1/metrics` in Prometheus form
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: vllm-stacker
-  namespace: vllm-stacker
+  name: sardeenz
+  namespace: sardeenz
 spec:
   selector:
     matchLabels:
-      app: vllm-stacker
+      app: sardeenz
   endpoints:
-  - port: controller
-    path: /api/v1/metrics
-    interval: 30s
+    - port: controller
+      path: /api/v1/metrics
+      interval: 30s
 ```
 
 ### Grafana Dashboard
@@ -625,6 +757,7 @@ spec:
 Import dashboard for visualization (ID: TBD, to be published).
 
 **Key Panels:**
+
 - Model instance status (gauge)
 - GPU memory usage (time series)
 - Request latency (histogram)
@@ -671,35 +804,68 @@ oc exec -it <pod-name> -- curl http://localhost:3000/api/health
 
 **Solution:** Check for application errors in logs.
 
-**4. OAuth Authentication Errors**
+**4. Authentication Errors**
 
 ```bash
-# Verify OAuth secret
-oc get secret oauth-config -o yaml
+# Check auth mode
+oc exec -it <pod-name> -- env | grep AUTH_MODE
 
-# Check issuer URL reachability
-oc exec -it <pod-name> -- curl <issuer-url>/.well-known/openid-configuration
+# For OAuth: Verify secret and issuer URL
+oc get secret oauth-config -o yaml
+oc exec -it <pod-name> -- curl ${K8S_API_URL}/apis/user.openshift.io/v1/users/~
+
+# For simple mode: Verify credentials are set
+oc exec -it <pod-name> -- env | grep -E 'ADMIN_USERNAME|ADMIN_PASSWORD'
 ```
 
-**Solution:** Verify OAuth configuration and network policies.
+**Solution:** Verify auth configuration matches the `AUTH_MODE` setting.
+
+**5. Authorization Errors (Access Denied)**
+
+If users see the Access Denied page after OAuth login, they have successfully authenticated but are not members of any authorized groups.
+
+```bash
+# Check user's group membership
+oc get users <username> -o yaml
+
+# List members of sardeenz groups
+oc get group sardeenz-admins -o yaml
+oc get group sardeenz-admins-readonly -o yaml
+
+# Add user to appropriate group
+oc adm groups add-users sardeenz-admins <username>
+
+# Verify the groups exist
+oc get groups | grep sardeenz
+```
+
+**Common issues:**
+
+- **User not in any authorized group** → Add user to `sardeenz-admins` or `sardeenz-admins-readonly`
+- **Groups don't exist** → Create groups with `oc adm groups new sardeenz-admins`
+- **Group names misspelled** → Must be exactly `sardeenz-admins` or `sardeenz-admins-readonly`
+- **K8S_API_URL incorrect** → Verify URL and connectivity from pod
+
+**Solution:** Add user to the appropriate group, then have them click "Try Again" on the Access Denied page to re-authenticate.
 
 ### Debug Mode
 
 Enable debug logging:
 
 ```bash
-oc set env deployment/vllm-stacker LOG_LEVEL=debug
+oc set env deployment/sardeenz LOG_LEVEL=debug
 ```
 
 View detailed logs:
 
 ```bash
-oc logs -f deployment/vllm-stacker | jq .
+oc logs -f deployment/sardeenz | jq .
 ```
 
 ---
 
 **See Also:**
+
 - [Architecture](./architecture.md) - System architecture and design
 - [API Guide](./api-guide.md) - API usage examples
 - [KVCached Documentation](./kvcached/) - GPU memory sharing setup

--- a/docs/development/frontend-api-client.md
+++ b/docs/development/frontend-api-client.md
@@ -23,7 +23,7 @@ The frontend communicates with the **Controller API** (`http://localhost:3000/ap
 - Access operation audit trail
 
 **Key Requirements:**
-- OAuth/OIDC authentication with JWT bearer tokens
+- OAuth 2.0 authentication with JWT bearer tokens
 - Role-based access control (admin, admin-readonly)
 - Automatic token refresh
 - Graceful error handling
@@ -38,7 +38,7 @@ src/api/
 ├── client.ts          # Axios instance with interceptors
 ├── models.ts          # Model lifecycle endpoints
 ├── metrics.ts         # Metrics endpoints
-├── types.ts           # API response types (imports from @vllm-stacker/types)
+├── types.ts           # API response types (imports from @sardeenz/types)
 └── index.ts           # Re-export all APIs
 ```
 
@@ -111,7 +111,7 @@ VITE_API_BASE_URL=/api/v1
 
 ## Authentication Integration
 
-### OAuth/OIDC Flow
+### OAuth 2.0 Flow
 
 The frontend delegates OAuth authentication to the backend:
 
@@ -241,7 +241,7 @@ export const useAuth = (): AuthContextType => {
 
 ```tsx
 import { apiClient } from './client';
-import { ModelInstance } from '@vllm-stacker/types';
+import { ModelInstance } from '@sardeenz/types';
 
 export interface LoadModelRequest {
   modelPath: string;
@@ -384,7 +384,7 @@ export * from './types';
 ```tsx
 import { useState, useEffect, useCallback } from 'react';
 import { modelsApi } from '../api/models';
-import { ModelInstance } from '@vllm-stacker/types';
+import { ModelInstance } from '@sardeenz/types';
 
 interface UseModelsResult {
   models: ModelInstance[];
@@ -439,7 +439,7 @@ export function useModels(
 ```tsx
 import { useState, useEffect } from 'react';
 import { modelsApi } from '../api/models';
-import { ModelInstance } from '@vllm-stacker/types';
+import { ModelInstance } from '@sardeenz/types';
 
 interface UseModelDetailsResult {
   model: ModelInstance | null;
@@ -674,7 +674,7 @@ export type {
   ModelConfiguration,
   ResourceMetrics,
   ControllerOperation,
-} from '@vllm-stacker/types';
+} from '@sardeenz/types';
 
 // Frontend-specific types
 export interface ModelFormData {

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -8,7 +8,7 @@ This directory contains Kubernetes manifests for deploying Sardeenz to OpenShift
 - NVIDIA GPU nodes with proper taints/labels
 - `oc` CLI (OpenShift) or `kubectl` (Kubernetes)
 - Access to container registry for pushing images
-- OAuth 2.0/OIDC provider (optional, for authentication)
+- OAuth 2.0 provider (optional, for authentication)
 
 ## Quick Start
 
@@ -25,9 +25,9 @@ docker push quay.io/your-org/sardeenz:latest
 ### 2. Create Namespace
 
 ```bash
-oc new-project vllm-stacker
+oc new-project sardeenz
 # or
-kubectl create namespace vllm-stacker
+kubectl create namespace sardeenz
 ```
 
 ### 3. Configure OAuth Credentials (Optional)
@@ -35,11 +35,11 @@ kubectl create namespace vllm-stacker
 If using authentication, create the OAuth secret:
 
 ```bash
-oc create secret generic vllm-stacker-oauth \
+oc create secret generic sardeenz-oauth \
   --from-literal=client-id=$OAUTH_CLIENT_ID \
   --from-literal=client-secret=$OAUTH_CLIENT_SECRET \
   --from-literal=issuer-url=$OAUTH_ISSUER_URL \
-  -n vllm-stacker
+  -n sardeenz
 ```
 
 Or edit `secret.yaml` and replace placeholder values before applying.
@@ -70,16 +70,16 @@ oc apply -f k8s/route.yaml
 
 ```bash
 # Check deployment status
-oc get deployment sardeenz -n vllm-stacker
+oc get deployment sardeenz -n sardeenz
 
 # Check pod status (should show GPU assigned)
-oc get pods -n vllm-stacker -o wide
+oc get pods -n sardeenz -o wide
 
 # Check logs
-oc logs -f deployment/sardeenz -n vllm-stacker
+oc logs -f deployment/sardeenz -n sardeenz
 
 # Get external URL (OpenShift only)
-oc get route sardeenz -n vllm-stacker -o jsonpath='{.spec.host}'
+oc get route sardeenz -n sardeenz -o jsonpath='{.spec.host}'
 ```
 
 ## Manifest Files
@@ -215,7 +215,7 @@ readinessProbe:
 
 The deployment requires a PVC for caching Hugging Face models:
 
-- **Name:** `vllm-stacker-model-cache`
+- **Name:** `sardeenz-model-cache`
 - **Size:** 100Gi (adjust based on model sizes)
 - **Access Mode:** ReadWriteOnce
 - **Mount Path:** `/root/.cache/huggingface`
@@ -289,18 +289,18 @@ spec:
 
 ## Security
 
-### OAuth/OIDC Authentication
+### OAuth 2.0 Authentication
 
 To enable authentication, configure the OAuth secret and set environment variables:
 
-1. **Create OAuth application** in your identity provider (Keycloak, Auth0, etc.)
-2. **Set redirect URI** to `https://<route-host>/auth/callback`
+1. **Create OAuth application** in your identity provider (OpenShift OAuth, Keycloak, etc.)
+2. **Set redirect URI** to `https://<route-host>/api/auth/callback`
 3. **Create secret** with credentials
 4. **Restart deployment** to pick up changes
 
 **The application supports:**
 - OAuth 2.0 Authorization Code flow
-- OIDC discovery
+- Manual OAuth configuration (for OpenShift OAuth and other non-OIDC providers)
 - JWT token validation
 - Role-based access control (admin, admin-readonly)
 
@@ -428,7 +428,7 @@ oc adm top pod -l app=sardeenz
 ```bash
 # Update image tag in deployment
 oc set image deployment/sardeenz \
-  vllm-stacker=quay.io/your-org/sardeenz:v1.1.0
+  sardeenz=quay.io/your-org/sardeenz:v1.1.0
 
 # Watch rollout
 oc rollout status deployment/sardeenz
@@ -456,9 +456,9 @@ kubectl delete -k k8s/
 ### Delete Namespace
 
 ```bash
-oc delete project vllm-stacker
+oc delete project sardeenz
 # or
-kubectl delete namespace vllm-stacker
+kubectl delete namespace sardeenz
 ```
 
 **Note:** This deletes the PVC and model cache. Back up models first if needed.

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: sardeenz
 type: Opaque
 stringData:
-  # OAuth 2.0 / OIDC configuration
+  # OAuth 2.0 configuration
   # Replace these placeholder values with your actual OAuth provider credentials
 
   # OAuth Client ID (from your OAuth provider)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
     },
     "apps/backend": {
       "name": "@sardeenz/backend",
-      "version": "0.1.0",
       "dependencies": {
         "@fastify/cors": "^10.0.1",
         "@fastify/jwt": "^9.0.1",
@@ -93,7 +92,6 @@
     },
     "apps/frontend": {
       "name": "@sardeenz/frontend",
-      "version": "0.1.0",
       "dependencies": {
         "@nivo/bar": "^0.99.0",
         "@nivo/core": "^0.99.0",
@@ -14281,12 +14279,10 @@
       }
     },
     "packages/contracts": {
-      "name": "@sardeenz/contracts",
-      "version": "0.1.0"
+      "name": "@sardeenz/contracts"
     },
     "packages/types": {
       "name": "@sardeenz/types",
-      "version": "0.1.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.9"
       },
@@ -14300,7 +14296,6 @@
     },
     "packages/utils": {
       "name": "@sardeenz/utils",
-      "version": "0.1.0",
       "dependencies": {
         "@sinclair/typebox": "^0.34.9",
         "pino": "^9.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sardeenz",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Multi-model vLLM management platform with dynamic loading and unified inference proxy",
   "private": true,
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@sardeenz/contracts",
-  "version": "0.1.0",
   "description": "OpenAPI contracts for Sardeenz APIs",
   "private": true,
   "files": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@sardeenz/types",
-  "version": "0.1.0",
   "description": "Shared TypeScript types for Sardeenz",
   "private": true,
   "type": "module",

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,78 @@
+/**
+ * Authentication types shared between backend and frontend
+ */
+
+/**
+ * Authentication mode configuration
+ * - none: No authentication required
+ * - simple: Username/password authentication with JWT
+ * - oauth: OAuth 2.0 authentication (e.g., OpenShift OAuth)
+ */
+export type AuthMode = 'none' | 'simple' | 'oauth'
+
+/**
+ * User information returned after authentication
+ */
+export interface AuthUser {
+  username: string
+  email?: string
+  roles: string[]
+}
+
+/**
+ * Response from /api/auth/info endpoint
+ * Frontend uses this to determine which login UI to show
+ */
+export interface AuthInfoResponse {
+  mode: AuthMode
+  oauthLoginUrl?: string
+}
+
+/**
+ * Request body for /api/auth/login endpoint (simple mode)
+ */
+export interface LoginRequest {
+  username: string
+  password: string
+}
+
+/**
+ * Response from /api/auth/login endpoint
+ */
+export interface LoginResponse {
+  token: string
+  user: AuthUser
+  expiresIn: number
+}
+
+/**
+ * Response from /api/auth/me endpoint
+ */
+export interface CurrentUserResponse {
+  username: string
+  email?: string
+  roles: string[]
+  authMode: 'simple' | 'oauth'
+  /** Inference API key for OpenAI-compatible endpoints (only when INFERENCE_API_KEY is configured) */
+  inferenceApiKey?: string
+}
+
+/**
+ * Response from /api/auth/logout endpoint
+ */
+export interface LogoutResponse {
+  status: 'success'
+}
+
+/**
+ * JWT payload structure used internally
+ */
+export interface JWTPayload {
+  sub: string
+  username: string
+  email?: string
+  roles: string[]
+  authMode: 'simple' | 'oauth'
+  iat: number
+  exp: number
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,3 +24,6 @@ export * from './schemas/benchmark.js'
 
 // Export model configuration validation schemas
 export * from './schemas/model-configuration.js'
+
+// Export authentication types
+export * from './auth.js'

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@sardeenz/utils",
-  "version": "0.1.0",
   "description": "Shared utilities for Sardeenz",
   "private": true,
   "type": "module",

--- a/specs/001-multi-model-platform/contracts/README.md
+++ b/specs/001-multi-model-platform/contracts/README.md
@@ -10,7 +10,7 @@ This directory contains OpenAPI 3.1 specifications for the Sardeenz platform.
 
 **Base Path**: `/api`
 
-**Authentication**: OAuth 2.0 / OIDC required
+**Authentication**: OAuth 2.0 required
 
 **Endpoints**:
 - `POST /models/load` - Load a new model (requires `admin` role)

--- a/specs/001-multi-model-platform/contracts/controller-api.yaml
+++ b/specs/001-multi-model-platform/contracts/controller-api.yaml
@@ -10,7 +10,7 @@ info:
     - Query model status and resource usage
     - Monitor model health and performance
 
-    **Authentication**: OAuth 2.0 / OIDC required for all endpoints.
+    **Authentication**: OAuth 2.0 required for all endpoints.
     **Roles**:
     - `admin`: Full access (load, unload, configure)
     - `admin-readonly`: Read-only access (list, status, metrics)
@@ -389,7 +389,7 @@ components:
   securitySchemes:
     OAuth2:
       type: oauth2
-      description: OAuth 2.0 / OIDC authentication with role-based access control
+      description: OAuth 2.0 authentication with role-based access control
       flows:
         authorizationCode:
           authorizationUrl: https://keycloak.example.com/realms/vllm/protocol/openid-connect/auth

--- a/specs/001-multi-model-platform/plan.md
+++ b/specs/001-multi-model-platform/plan.md
@@ -21,7 +21,7 @@ Create a multi-model vLLM management platform that enables dynamic loading/unloa
 - **Monorepo**: npm workspaces (apps/backend, apps/frontend, packages/types)
 - **Container**: Based on `quay.io/vllm/vllm-cuda:0.11.2` with Node.js 22 added
 - **Process Management**: Direct subprocess spawning with KVCached memory sharing (NOT using KVCached Controller)
-- **Auth**: OAuth 2.0 / OIDC with RBAC (admin, admin-readonly roles)
+- **Auth**: OAuth 2.0 with RBAC (admin, admin-readonly roles)
 
 ## Technical Context
 
@@ -58,7 +58,7 @@ Create a multi-model vLLM management platform that enables dynamic loading/unloa
 **Constraints**:
 - GPU memory: Shared via KVCached, fair allocation required (prevent OOM)
 - No database dependency for PoC (in-memory storage acceptable)
-- OAuth/OIDC integration required from start (security by design)
+- OAuth 2.0 integration required from start (security by design)
 - OpenAI-compatible API format (enables drop-in replacement)
 - Stateless operation (container restarts = clean state)
 
@@ -129,7 +129,7 @@ Create a multi-model vLLM management platform that enables dynamic loading/unloa
 
 **Status**: **COMPLIANT**
 
-- ✅ OAuth 2.0 / OIDC integration via `@fastify/oauth2`
+- ✅ OAuth 2.0 integration via manual OAuth flow (OpenShift compatible)
 - ✅ RBAC roles defined: `admin` (full access), `admin-readonly` (read-only)
 - ✅ Role enforcement at endpoint level (decorators)
 - ✅ JWT claims validation for group membership
@@ -264,7 +264,7 @@ specs/[###-feature]/
 │   │   │   │   ├── metrics.ts          # Prometheus metrics collection
 │   │   │   │   └── proxy-router.ts     # Request routing to model instances
 │   │   │   └── plugins/           # Fastify plugins
-│   │   │       ├── auth.ts        # OAuth/OIDC + RBAC
+│   │   │       ├── auth.ts        # OAuth 2.0 + RBAC
 │   │   │       ├── swagger.ts     # OpenAPI documentation
 │   │   │       └── metrics.ts     # Prometheus metrics plugin
 │   │   ├── tests/                 # Backend tests

--- a/specs/001-multi-model-platform/quickstart.md
+++ b/specs/001-multi-model-platform/quickstart.md
@@ -79,7 +79,7 @@ sardeenz/
 │   │   │   │   ├── memory-monitor.ts  # KVCached memory monitoring
 │   │   │   │   └── metrics.ts         # Prometheus metrics
 │   │   │   └── plugins/           # Fastify plugins
-│   │   │       ├── auth.ts        # OAuth/OIDC plugin
+│   │   │       ├── auth.ts        # OAuth 2.0 plugin
 │   │   │       └── swagger.ts     # OpenAPI plugin
 │   │   ├── tests/                 # Backend tests
 │   │   │   ├── integration/       # API integration tests
@@ -218,10 +218,11 @@ cat > apps/backend/.env <<EOF
 PORT=3000
 NODE_ENV=development
 
-# OAuth/OIDC Configuration
-OAUTH_CLIENT_ID=vllm-stacker
+# OAuth 2.0 Configuration
+OAUTH_CLIENT_ID=sardeenz
 OAUTH_CLIENT_SECRET=change-me-in-production
-OIDC_ISSUER_URL=https://keycloak.example.com/realms/vllm
+OAUTH_ISSUER_URL=https://oauth-openshift.apps.example.com
+K8S_API_URL=https://api.example.com:6443
 JWT_SECRET=change-me-in-production
 API_BASE_URL=http://localhost:3000
 

--- a/specs/001-multi-model-platform/research.md
+++ b/specs/001-multi-model-platform/research.md
@@ -8,7 +8,7 @@
 
 1. [Fastify Best Practices for TypeScript](#1-fastify-best-practices-for-typescript)
 2. [KVCached Subprocess Management](#2-kvcached-subprocess-management)
-3. [OAuth/OIDC Integration](#3-oauthoidc-integration)
+3. [OAuth 2.0 Integration](#3-oauth-20-integration)
 4. [Streaming Proxy Implementation](#4-streaming-proxy-implementation)
 5. [Prometheus Metrics in Fastify](#5-prometheus-metrics-in-fastify)
 6. [PatternFly 6 + Vite Setup](#6-patternfly-6--vite-setup)
@@ -272,12 +272,12 @@ export class ModelManager extends EventEmitter {
 
 ---
 
-## 3. OAuth/OIDC Integration
+## 3. OAuth 2.0 Integration
 
-### Decision: Use `@fastify/oauth2` with Keycloak/generic OIDC provider
+### Decision: Use manual OAuth 2.0 flow for OpenShift compatibility
 
 **Rationale:**
-- Enterprise-grade authentication via OAuth 2.0 / OIDC (constitution requirement)
+- Enterprise-grade authentication via OAuth 2.0 (constitution requirement)
 - Supports role-based access control via JWT claims
 - Compatible with Keycloak, Auth0, Okta, Azure AD
 - Fastify-native plugin with TypeScript support
@@ -299,7 +299,7 @@ export default fp(async (fastify) => {
 
   // Register OAuth2 plugin
   await fastify.register(oauth2, {
-    name: 'oidcAuth',
+    name: 'oauth2Auth',
     scope: ['openid', 'profile', 'email'],
     credentials: {
       client: {
@@ -311,7 +311,7 @@ export default fp(async (fastify) => {
     startRedirectPath: '/auth/login',
     callbackUri: `${process.env.API_BASE_URL}/auth/callback`,
     discovery: {
-      issuer: process.env.OIDC_ISSUER_URL!, // e.g., https://keycloak.example.com/realms/myrealm
+      issuer: process.env.OAUTH_ISSUER_URL!, // e.g., https://oauth-openshift.apps.example.com
     },
   })
 
@@ -357,7 +357,8 @@ fastify.get('/api/models', {
 **Required Environment Variables:**
 - `OAUTH_CLIENT_ID`: OAuth client ID
 - `OAUTH_CLIENT_SECRET`: OAuth client secret
-- `OIDC_ISSUER_URL`: OIDC issuer URL (e.g., Keycloak realm)
+- `OAUTH_ISSUER_URL`: OAuth issuer URL (e.g., OpenShift OAuth server)
+- `K8S_API_URL`: Kubernetes API URL for user info lookup
 - `JWT_SECRET`: Secret for signing/verifying JWTs
 - `API_BASE_URL`: Base URL for callback redirect
 
@@ -885,7 +886,7 @@ export const ModelDashboard: React.FC = () => {
 
 ```json
 {
-  "name": "@vllm-stacker/backend",
+  "name": "@sardeenz/backend",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -896,8 +897,8 @@ export const ModelDashboard: React.FC = () => {
   },
   "dependencies": {
     "fastify": "^5.1.0",
-    "@vllm-stacker/types": "workspace:*",
-    "@vllm-stacker/utils": "workspace:*"
+    "@sardeenz/types": "workspace:*",
+    "@sardeenz/utils": "workspace:*"
   },
   "devDependencies": {
     "tsx": "^4.19.0",
@@ -927,8 +928,8 @@ export const ModelDashboard: React.FC = () => {
     "sourceMap": true,
     "composite": true,
     "paths": {
-      "@vllm-stacker/types": ["./packages/types/src"],
-      "@vllm-stacker/utils": ["./packages/utils/src"]
+      "@sardeenz/types": ["./packages/types/src"],
+      "@sardeenz/utils": ["./packages/utils/src"]
     }
   }
 }
@@ -953,7 +954,7 @@ export const ModelDashboard: React.FC = () => {
 |------|----------|------------------|-----------|
 | **Backend Framework** | Fastify with TypeScript | `fastify@^5.1.0` | Performance (<50ms routing), TypeScript support, OpenAPI integration |
 | **Process Management** | Direct subprocess | Node.js `child_process` | Full control, no downtime on model changes, KVCached compatible |
-| **Authentication** | OAuth 2.0 / OIDC | `@fastify/oauth2@^8.1.0` | Enterprise-grade auth, RBAC via JWT claims, SSO support |
+| **Authentication** | OAuth 2.0 | Manual OAuth flow | Enterprise-grade auth, RBAC via JWT claims, OpenShift OAuth compatible |
 | **Streaming Proxy** | Fastify reply.hijack() | Built-in | Minimal latency, direct TCP passthrough |
 | **Metrics** | Prometheus | `fastify-metrics@^11.0.0` | Industry standard, custom metrics support |
 | **Frontend** | React + PatternFly 6 + Vite | `vite@^6.0.0`, `@patternfly/react-core@^6.0.0` | Fast dev server, enterprise UI components, TypeScript support |

--- a/specs/001-multi-model-platform/tasks.md
+++ b/specs/001-multi-model-platform/tasks.md
@@ -72,7 +72,7 @@ This is a monorepo with npm workspaces:
 - [X] T026 Create apps/backend/tsconfig.json extending tsconfig.base.json
 - [X] T027 Create environment configuration loader in apps/backend/src/config.ts
 - [X] T028 Create Fastify server initialization in apps/backend/src/server.ts with TypeBox type provider
-- [X] T029 [P] Create OAuth/OIDC authentication plugin in apps/backend/src/plugins/auth.ts
+- [X] T029 [P] Create OAuth 2.0 authentication plugin in apps/backend/src/plugins/auth.ts
 - [X] T030 [P] Create Swagger/OpenAPI documentation plugin in apps/backend/src/plugins/swagger.ts
 - [X] T031 [P] Create Prometheus metrics plugin in apps/backend/src/plugins/metrics.ts
 - [X] T032 [P] Create error handling utilities in apps/backend/src/utils/errors.ts
@@ -408,7 +408,7 @@ Task T009: "Initialize packages/utils workspace"
 Task T010: "Initialize packages/contracts workspace"
 
 # All backend plugins can run together:
-Task T029: "Create OAuth/OIDC plugin in apps/backend/src/plugins/auth.ts"
+Task T029: "Create OAuth 2.0 plugin in apps/backend/src/plugins/auth.ts"
 Task T030: "Create Swagger plugin in apps/backend/src/plugins/swagger.ts"
 Task T031: "Create Prometheus metrics plugin in apps/backend/src/plugins/metrics.ts"
 ```


### PR DESCRIPTION
## Summary

- Implements dual-authentication model separating admin auth (JWT) from inference auth (API key)
- Admin authentication supports three modes: `none`, `simple` (username/password), and `oauth` (OAuth 2.0)
- Inference endpoints (`/v1/*`) now support optional API key authentication via `INFERENCE_API_KEY`
- Adds frontend login page, protected routes, and auth context
- Updates all documentation (api-guide, deployment, architecture) with authentication details

## Changes

**Backend:**
- New auth plugin with configurable `AUTH_MODE` (none/simple/oauth)
- New inference-auth plugin for OpenAI-compatible endpoint protection
- JWT-based session management with refresh tokens
- OAuth 2.0 authorization code flow support
- New `/api/auth/*` routes for login, logout, token refresh, and OAuth callbacks

**Frontend:**
- `AuthContext` for managing authentication state
- `ProtectedRoute` component for route protection
- Login page with username/password and OAuth support
- OAuth callback handler and access denied page
- API client updated with automatic token refresh and auth headers

**Types:**
- New `packages/types/src/auth.ts` with auth-related type definitions

## Test plan

- [x] Verify `AUTH_MODE=none` allows unrestricted dashboard access
- [x] Test `AUTH_MODE=simple` login/logout flow with credentials
- [x] Confirm JWT refresh tokens work correctly
- [x] Test inference API key authentication on `/v1/*` endpoints
- [x] Verify OAuth flow with a configured provider (if available)