### PR TITLE
feat(model-manager): add robust unload with unload-all UI support

### DIFF
--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -61,6 +61,17 @@ async function authPlugin(fastify: FastifyInstance) {
         return
       }
 
+      // Check for token in query params (fallback for EventSource/SSE which can't send headers)
+      const queryToken = (request.query as { token?: string })?.token
+      if (queryToken) {
+        try {
+          request.user = fastify.jwt.verify<JWTPayload>(queryToken)
+          return
+        } catch {
+          // Fall through to standard error handling
+        }
+      }
+
       try {
         await request.jwtVerify()
       } catch {

--- a/apps/backend/src/routes/model-configurations.ts
+++ b/apps/backend/src/routes/model-configurations.ts
@@ -21,7 +21,7 @@ import {
 } from '@sardeenz/types'
 import { getModelConfigurationStore } from '../stores/model-configuration-store.js'
 import { modelStore } from '../stores/model-store.js'
-import { ModelManager } from '../services/model-manager.js'
+import { getModelManager } from '../services/model-manager.js'
 
 const ConfigIdParamsSchema = Type.Object({
   id: Type.String({ format: 'uuid' }),
@@ -53,7 +53,7 @@ function configToResponse(config: SavedModelConfiguration) {
 
 export default async function modelConfigurationRoutes(fastify: FastifyInstance) {
   const store = getModelConfigurationStore()
-  const modelManager = new ModelManager(fastify.log)
+  const modelManager = getModelManager(fastify.log)
 
   /**
    * GET /api/configurations - List all configurations

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -13,7 +13,7 @@ import {
   type ModelInstanceDTO,
   type LoadModelRequestType,
 } from '@sardeenz/types'
-import { ModelManager } from '../services/model-manager.js'
+import { getModelManager } from '../services/model-manager.js'
 import { modelStore } from '../stores/model-store.js'
 import { operationStore } from '../stores/operation-store.js'
 import { NotFoundError, AppError } from '../utils/errors.js'
@@ -22,7 +22,7 @@ import type { ModelInstance, ControllerOperation } from '@sardeenz/types'
 import { OperationStatus, OperationType } from '@sardeenz/types'
 
 export default async function modelsRoutes(fastify: FastifyInstance) {
-  const modelManager = new ModelManager(fastify.log)
+  const modelManager = getModelManager(fastify.log)
 
   // Helper to convert ModelInstance to DTO
   function toDTO(instance: ModelInstance): ModelInstanceDTO {

--- a/apps/backend/src/services/model-manager.ts
+++ b/apps/backend/src/services/model-manager.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto'
 import type { ModelInstance, ModelStatus } from '@sardeenz/types'
 import { modelStore } from '../stores/model-store.js'
 import { config } from '../config.js'
-import { getNextPort, killProcessImmediate, isProcessRunning, getDescendantPids } from '../utils/process.js'
+import { getNextPort, killProcessImmediate, isProcessRunning, getDescendantPids, findVllmProcessesByPort, findProcessesByEnvMarker } from '../utils/process.js'
 import { NotFoundError, InternalError } from '../utils/errors.js'
 import { buildErrorMessage } from '../utils/error-parser.js'
 import { parseMemoryMetrics, extractEngineCorePid } from '../utils/memory-parser.js'
@@ -179,6 +179,7 @@ export class ModelManager extends EventEmitter {
       const proc = spawn('vllm', allArgs, {
         env: {
           ...process.env,
+          SARDEENZ_INSTANCE_ID: instanceId, // Marker for process cleanup on unload
           CUDA_VISIBLE_DEVICES: targetGpuIds.join(','), // GPU restriction
           ENABLE_KVCACHED: enableKvcached ? 'true' : 'false',
           KVCACHED_AUTOPATCH: config.kvcachedAutopatch && enableKvcached ? '1' : '0',
@@ -547,6 +548,51 @@ export class ModelManager extends EventEmitter {
       // the shared KVCached IPC segment (kvcached_mem_info)
       await killProcessImmediate(proc)
 
+      // Explicitly kill EngineCore if tracked (may not be a descendant of the main process)
+      if (instance.engineCorePid) {
+        try {
+          process.kill(instance.engineCorePid, 'SIGKILL')
+          this.logger.debug({ instanceId: instance.id, engineCorePid: instance.engineCorePid }, 'Killed EngineCore process')
+        } catch {
+          // Process may have already exited
+        }
+      }
+
+      // Find and kill any remaining processes with our instance marker env var
+      // This catches ALL child processes (EngineCore, tensor parallelism workers)
+      // even if they re-parented to init and don't appear in the process tree
+      const markedPids = await findProcessesByEnvMarker('SARDEENZ_INSTANCE_ID', instance.id)
+      if (markedPids.length > 0) {
+        this.logger.info(
+          { instanceId: instance.id, markedPids },
+          'Found processes with instance marker, killing them'
+        )
+        for (const pid of markedPids) {
+          try {
+            process.kill(pid, 'SIGKILL')
+          } catch {
+            // Process may have already exited
+          }
+        }
+      }
+
+      // Also try port-based discovery as a fallback for older instances
+      // that were started before the marker was added
+      const portPids = await findVllmProcessesByPort(instance.port)
+      if (portPids.length > 0) {
+        this.logger.info(
+          { instanceId: instance.id, portPids, port: instance.port },
+          'Found remaining vLLM processes by port, killing them'
+        )
+        for (const pid of portPids) {
+          try {
+            process.kill(pid, 'SIGKILL')
+          } catch {
+            // Process may have already exited
+          }
+        }
+      }
+
       // Note: We intentionally do NOT delete the IPC segment here.
       // All models share 'kvcached_mem_info' - it's only deleted on server shutdown.
 
@@ -775,4 +821,18 @@ export class ModelManager extends EventEmitter {
       lineCount: buffer.length,
     }
   }
+}
+
+// Singleton instance
+let _modelManagerInstance: ModelManager | null = null
+
+/**
+ * Get the singleton ModelManager instance.
+ * This ensures all routes share the same instance and its processes Map.
+ */
+export function getModelManager(logger: Logger): ModelManager {
+  if (!_modelManagerInstance) {
+    _modelManagerInstance = new ModelManager(logger)
+  }
+  return _modelManagerInstance
 }

--- a/apps/backend/src/services/orphan-detector.ts
+++ b/apps/backend/src/services/orphan-detector.ts
@@ -39,9 +39,12 @@ export class OrphanDetector {
     // Get all vLLM processes on the system
     const systemProcesses = await this.findVllmProcesses()
 
-    // Get PIDs tracked by the model store
+    // Get PIDs tracked by the model store (both processId and engineCorePid)
     const trackedInstances = modelStore.getAll()
-    const trackedPids = new Set(trackedInstances.map((i) => i.processId))
+    const trackedPids = new Set([
+      ...trackedInstances.map((i) => i.processId),
+      ...trackedInstances.filter((i) => i.engineCorePid).map((i) => i.engineCorePid!),
+    ])
 
     // Find orphans (running but not tracked)
     const orphans = systemProcesses.filter((proc) => !trackedPids.has(proc.pid))
@@ -80,9 +83,9 @@ export class OrphanDetector {
       }
     }
 
-    // Verify it's not tracked (safety check)
+    // Verify it's not tracked (safety check - includes both processId and engineCorePid)
     const trackedInstances = modelStore.getAll()
-    const isTracked = trackedInstances.some((i) => i.processId === pid)
+    const isTracked = trackedInstances.some((i) => i.processId === pid || i.engineCorePid === pid)
 
     if (isTracked) {
       return {

--- a/apps/backend/src/utils/process.ts
+++ b/apps/backend/src/utils/process.ts
@@ -223,3 +223,98 @@ export async function getDescendantPids(parentPid: number): Promise<number[]> {
 
   return descendants
 }
+
+/**
+ * Find all vLLM-related processes by port number.
+ * Searches for processes containing 'vllm' with --port=<port> in their args.
+ * This is more reliable than tree-walking for processes that may have
+ * escaped the parent-child hierarchy (e.g., Python multiprocessing workers).
+ */
+export async function findVllmProcessesByPort(port: number): Promise<number[]> {
+  return new Promise((resolve) => {
+    const pids: number[] = []
+
+    // Use ps to find all processes with their args
+    const ps = spawn('ps', ['-eo', 'pid,args'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+
+    ps.stdout?.on('data', (data) => {
+      stdout += data.toString()
+    })
+
+    ps.on('error', () => {
+      resolve([])
+    })
+
+    ps.on('exit', () => {
+      const lines = stdout.split('\n').slice(1) // Skip header
+
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+
+        // Only consider vLLM processes
+        if (!trimmed.includes('vllm')) continue
+
+        // Skip grep/ps itself
+        if (trimmed.includes('grep') || trimmed.includes('ps -eo')) continue
+
+        // Check if this process has the target port
+        const portPattern = new RegExp(`--port[=\\s]?${port}(?:\\s|$)`)
+        if (!portPattern.test(trimmed)) continue
+
+        // Extract PID (first token)
+        const tokens = trimmed.split(/\s+/)
+        const pid = parseInt(tokens[0], 10)
+        if (isNaN(pid)) continue
+
+        // Skip self
+        if (pid === process.pid) continue
+
+        pids.push(pid)
+      }
+
+      resolve(pids)
+    })
+  })
+}
+
+/**
+ * Find all processes with a specific environment variable.
+ * Reads /proc/<pid>/environ for each process on the system.
+ * This is useful for finding child processes that may have re-parented to init
+ * but still carry the inherited environment variable.
+ */
+export async function findProcessesByEnvMarker(envName: string, envValue: string): Promise<number[]> {
+  const pids: number[] = []
+  const marker = `${envName}=${envValue}`
+
+  try {
+    const procDirs = await fs.promises.readdir('/proc')
+
+    for (const dir of procDirs) {
+      const pid = parseInt(dir, 10)
+      if (isNaN(pid)) continue
+
+      // Skip self
+      if (pid === process.pid) continue
+
+      try {
+        // /proc/<pid>/environ contains null-separated KEY=value pairs
+        const environ = await fs.promises.readFile(`/proc/${pid}/environ`, 'utf-8')
+        if (environ.includes(marker)) {
+          pids.push(pid)
+        }
+      } catch {
+        // Process may have exited or we don't have permission
+      }
+    }
+  } catch {
+    // /proc not accessible (non-Linux system)
+  }
+
+  return pids
+}

--- a/apps/frontend/src/hooks/useInstanceEvents.ts
+++ b/apps/frontend/src/hooks/useInstanceEvents.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import type { SSEEvent, SSEEventType, LogEvent, StatusEvent } from '@sardeenz/types'
+import { apiClient } from '../services/api'
 
 export interface UseInstanceEventsOptions {
   /** Instance ID to subscribe to. Pass null to not connect */
@@ -91,6 +92,12 @@ export function useInstanceEvents(options: UseInstanceEventsOptions): UseInstanc
       params.set('types', currentEventTypes.join(','))
     }
     params.set('replay_logs', String(replayLogsRef.current))
+
+    // Add auth token for SSE (EventSource can't send Authorization header)
+    const token = apiClient.getAuthToken()
+    if (token) {
+      params.set('token', token)
+    }
 
     const url = `${baseURL}/api/models/instances/${instanceId}/events?${params}`
 

--- a/apps/frontend/src/pages/ModelManagement.tsx
+++ b/apps/frontend/src/pages/ModelManagement.tsx
@@ -16,8 +16,12 @@ import {
   FlexItem,
   ClipboardCopy,
   ClipboardCopyVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
 } from '@patternfly/react-core'
-import { PlusCircleIcon, CubesIcon, SaveIcon, UploadIcon } from '@patternfly/react-icons'
+import { PlusCircleIcon, CubesIcon, SaveIcon, UploadIcon, TrashIcon } from '@patternfly/react-icons'
 import { apiClient } from '../services/api'
 import type { ModelInstanceDTO, LoadModelRequest } from '@sardeenz/types'
 import {
@@ -36,6 +40,8 @@ function ModelManagement() {
   const [unloadingInstanceId, setUnloadingInstanceId] = useState<string | null>(null)
   const [isSaveConfigOpen, setIsSaveConfigOpen] = useState(false)
   const [isLoadConfigOpen, setIsLoadConfigOpen] = useState(false)
+  const [isUnloadAllModalOpen, setIsUnloadAllModalOpen] = useState(false)
+  const [isUnloadingAll, setIsUnloadingAll] = useState(false)
 
   const { addNotification } = useNotifications()
 
@@ -128,6 +134,40 @@ function ModelManagement() {
     setTimeout(fetchModels, 2000)
   }
 
+  const handleUnloadAll = async () => {
+    setIsUnloadingAll(true)
+    try {
+      // Unload all models sequentially
+      for (const model of models) {
+        try {
+          await apiClient.unloadModelByInstanceId(model.id)
+        } catch (err) {
+          // Log but continue with other models
+          addNotification({
+            title: 'Failed to unload model',
+            description: `${model.model_path}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+            variant: 'warning',
+          })
+        }
+      }
+      addNotification({
+        title: 'All models unloaded',
+        description: 'Successfully unloaded all models',
+        variant: 'success',
+      })
+      await fetchModels()
+    } catch (err) {
+      addNotification({
+        title: 'Error unloading models',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'danger',
+      })
+    } finally {
+      setIsUnloadingAll(false)
+      setIsUnloadAllModalOpen(false)
+    }
+  }
+
   if (loading) {
     return (
       <PageSection>
@@ -180,6 +220,16 @@ function ModelManagement() {
                   onClick={() => setIsLoadConfigOpen(true)}
                 >
                   Load Config
+                </Button>
+              </FlexItem>
+              <FlexItem>
+                <Button
+                  variant="secondary"
+                  icon={<TrashIcon />}
+                  onClick={() => setIsUnloadAllModalOpen(true)}
+                  isDisabled={models.length === 0}
+                >
+                  Unload All
                 </Button>
               </FlexItem>
               <FlexItem>
@@ -254,6 +304,39 @@ function ModelManagement() {
         onLoadStarted={handleConfigLoadStarted}
         currentModelCount={runningModelCount}
       />
+
+      <Modal
+        variant="small"
+        isOpen={isUnloadAllModalOpen}
+        onClose={() => setIsUnloadAllModalOpen(false)}
+        aria-labelledby="unload-all-modal-title"
+        aria-describedby="unload-all-modal-body"
+      >
+        <ModalHeader title="Unload All Models" labelId="unload-all-modal-title" />
+        <ModalBody id="unload-all-modal-body">
+          Are you sure you want to unload all {models.length} model{models.length !== 1 ? 's' : ''}?
+          This will stop all inference services and free GPU memory.
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            key="confirm"
+            variant="danger"
+            onClick={handleUnloadAll}
+            isLoading={isUnloadingAll}
+            isDisabled={isUnloadingAll}
+          >
+            {isUnloadingAll ? 'Unloading...' : 'Unload All'}
+          </Button>
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => setIsUnloadAllModalOpen(false)}
+            isDisabled={isUnloadingAll}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
     </>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sardeenz",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Multi-model vLLM management platform with dynamic loading and unified inference proxy",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Implement comprehensive process cleanup during model unload and add
"Unload All" button to the frontend for batch model management.

Changes:
- Add SARDEENZ_INSTANCE_ID env marker to vLLM processes for reliable
  cleanup even when child processes re-parent to init
- Implement findProcessesByEnvMarker() to find processes by inherited
  environment variable via /proc/<pid>/environ
- Implement findVllmProcessesByPort() as fallback for older instances
- Explicitly kill EngineCore process and all marked descendants on
  unload
- Convert ModelManager to singleton pattern ensuring route handlers
  share the same process tracking state
- Add JWT token query param fallback in auth plugin for SSE clients
- Add "Unload All" button with confirmation modal in ModelManagement
  page

This ensures no orphaned vLLM/EngineCore processes remain after model
unload, even with tensor parallelism workers that escape the process
tree hierarchy.

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
