### PR TITLE
feat(memory): add per-GPU KVCache metrics with dynamic IPC segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .specify/scripts
 .specify/templates
 
-# Python virtual environment (for vLLM/KVCached)
+# Python virtual environment (for vLLM/kvcached)
 .venv/
 .uv/
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Per-GPU KVCache Metrics
+
+- **Per-GPU IPC segments**: Each GPU (or GPU-pair for tensor-parallel models) now gets its own IPC segment
+  - Single GPU: `kvcached_vllm_GPU0`, `kvcached_vllm_GPU1`, etc.
+  - Tensor-parallel: `kvcached_vllm_GPU0_GPU1` for models spanning multiple GPUs
+  - Replaces the old global `kvcached_mem_info` segment
+- **Memory baseline tracking**: Model memory footprint is now captured when loading completes (before any inference)
+  - New `memoryBaselineByGpu: Record<number, number>` field on ModelInstance
+  - Provides accurate idle memory measurement per GPU
+- **Accurate KVCache total calculation**: KVCache Total is now calculated dynamically
+  - Formula: `GPU Total - Model Baselines - Other Processes`
+  - Fixes stale total_size from IPC segment that was set at initialization and never updated
+- **Per-GPU KVCache metrics in API**: `/api/memory/usage/multi-gpu` now returns per-GPU `kvcache` metrics
+  - Each GPU shows its own `total_gb`, `used_gb`, `prealloc_gb`, `free_gb`
+  - Used/Prealloc values still read from IPC segments
+  - For tensor-parallel models, usage is split evenly across participating GPUs
+- **Automatic IPC naming**: `KVCACHED_IPC_NAME` environment variable is set automatically based on GPU assignment
+
 ## [0.2.1] - 2026-01-08
 
 ### Robust Model Unload
@@ -92,7 +112,7 @@ All notable changes to this project will be documented in this file.
 - GPU Selector service (`apps/backend/src/services/gpu-selector.ts`) auto-selects GPUs with most free memory
 - `GET /api/gpu/available` - Returns GPUs with availability info and recommendation
 - `GET /api/memory/usage/multi-gpu` - Per-GPU memory breakdown for multi-GPU systems
-- Models can span multiple GPUs via `tensor_parallel_size` parameter (KVCached disabled for tensor parallel)
+- Models can span multiple GPUs via `tensor_parallel_size` parameter (kvcached disabled for tensor parallel)
 - New fields in `LoadModelRequest`: `gpu_ids`, `tensor_parallel_size`
 - New fields in `ModelInstanceDTO`: `gpu_ids`, `tensor_parallel_size`, `kvcached_enabled`
 - Model Cards now display which GPU(s) each model is loaded on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**sardeenz** is a multi-model management platform that enables dynamic loading, management, and serving of multiple Large Language Models (LLMs) through a unified interface. Built on top of vLLM (inference engine) and KVCached (GPU memory sharing), it allows efficient multi-model hosting on a single GPU.
+**sardeenz** is a multi-model management platform that enables dynamic loading, management, and serving of multiple Large Language Models (LLMs) through a unified interface. Built on top of vLLM (inference engine) and kvcached (GPU memory sharing), it allows efficient multi-model hosting on a single GPU.
 
 **Core Components:**
 
@@ -40,7 +40,7 @@ npm run dev
 
 **Prerequisites:** Node.js 22.x, Python 3.12 + uv, NVIDIA GPU with CUDA 12.x, 8GB+ VRAM (16GB+ recommended)
 
-**GPU Setup:** On first run, the backend auto-creates a Python venv with vLLM/KVCached. See [`docs/dev-setup.md`](./docs/dev-setup.md) for details.
+**GPU Setup:** On first run, the backend auto-creates a Python venv with vLLM/kvcached. See [`docs/dev-setup.md`](./docs/dev-setup.md) for details.
 
 ## Architecture
 
@@ -77,8 +77,8 @@ npm run dev -w apps/backend          # Start backend only
 npm run dev -w apps/frontend         # Start frontend only
 
 # Container operations
-docker build -t sardeenz .
-docker run --gpus all -p 3000:3000 sardeenz
+make build VERSION=x.y.z           # Build image as quay.io/rh-aiservices-bu/sardeenz:x.y.z
+make push VERSION=x.y.z            # Push to registry
 ```
 
 ## Documentation
@@ -89,7 +89,7 @@ docker run --gpus all -p 3000:3000 sardeenz
 - [`docs/dev-setup.md`](./docs/dev-setup.md) - GPU development environment setup
 - [`docs/api-guide.md`](./docs/api-guide.md) - API usage examples
 - [`docs/deployment.md`](./docs/deployment.md) - Container and OpenShift deployment
-- [`docs/kvcached/`](./docs/kvcached/) - KVCached GPU memory sharing
+- [`docs/kvcached/`](./docs/kvcached/) - kvcached GPU memory sharing
 - [`CHANGELOG.md`](./CHANGELOG.md) - Project change history
 
 ## Active Technologies

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Sardeenz Container Build
+# Usage: make build VERSION=x.y.z
+
+IMAGE_REGISTRY := quay.io/rh-aiservices-bu
+IMAGE_NAME := sardeenz
+CONTAINERFILE := docker/Containerfile
+
+# Default version (can be overridden)
+VERSION ?= latest
+
+# Full image tag
+IMAGE_TAG := $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(VERSION)
+
+.PHONY: build push help
+
+## build: Build the container image (usage: make build VERSION=x.y.z)
+build:
+ifndef VERSION
+	$(error VERSION is required. Usage: make build VERSION=x.y.z)
+endif
+	podman build -t $(IMAGE_TAG) -f $(CONTAINERFILE) .
+	@echo "Built: $(IMAGE_TAG)"
+
+## push: Push the container image to registry
+push:
+	podman push $(IMAGE_TAG)
+	@echo "Pushed: $(IMAGE_TAG)"
+
+## build-push: Build and push in one step
+build-push: build push
+
+## help: Show this help
+help:
+	@echo "Sardeenz Container Build"
+	@echo ""
+	@echo "Usage:"
+	@echo "  make build VERSION=x.y.z    Build container image"
+	@echo "  make push VERSION=x.y.z     Push to quay.io"
+	@echo "  make build-push VERSION=x.y.z  Build and push"
+	@echo ""
+	@echo "Image: $(IMAGE_REGISTRY)/$(IMAGE_NAME):<VERSION>"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sardeenz is a proof-of-concept application that allows you to load more than one
 
 ## What is Sardeenz?
 
-Sardeenz is a multi-model management application that enables dynamic loading and serving of multiple Large Language Models (LLMs) through a unified interface. Built on top of **[vLLM](https://github.com/vllm-project/vllm)** and **[KVCached](https://github.com/ovg-project/kvcached)**, it provides efficient multi-model hosting with intelligent GPU resource management.
+Sardeenz is a multi-model management application that enables dynamic loading and serving of multiple Large Language Models (LLMs) through a unified interface. Built on top of **[vLLM](https://github.com/vllm-project/vllm)** and **[kvcached](https://github.com/ovg-project/kvcached)**, it provides efficient multi-model hosting with intelligent GPU resource management.
 
 **Why "Sardeenz"?** We were looking for a way to cram more models onto a GPU. "[Packed like sardines](https://wordhistories.net/2024/06/22/packed-like-sardines/)" captures the idea perfectly. Pronounced like [sardines](https://www.youtube.com/watch?v=Rr1dwxmeIOU).
 
@@ -34,7 +34,7 @@ See the [Deployment Guide](./docs/deployment.md) for full configuration options,
 - **Multi-GPU support** - Distribute models across GPUs with tensor parallelism
 - **OpenAI-compatible API** - Single endpoint drop-in replacement for all served models
 - **Web dashboard** - Manage models, monitor GPU memory, run benchmarks
-- **Memory sharing** - KVCached integration for efficient GPU utilization
+- **Memory sharing** - kvcached integration for efficient GPU utilization
 
 ## Screenshots
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -41,7 +41,7 @@ VLLM_MAX_INSTANCES=10
 # Model startup timeout in ms (default 30 min, increase for slow downloads)
 VLLM_STARTUP_TIMEOUT=1800000
 
-# KVCached configuration
+# kvcached configuration
 ENABLE_KVCACHED=true
 KVCACHED_AUTOPATCH=true
 

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -74,8 +74,8 @@ See `apps/backend/.env.example` for a complete reference.
 | `PORT`                 | 3000                      | Backend server port                                                                          |
 | `VLLM_BASE_PORT`       | 5001                      | Base port for vLLM instances                                                                 |
 | `VLLM_STARTUP_TIMEOUT` | 1800000                   | Model startup timeout in ms (30 min default)                                                 |
-| `ENABLE_KVCACHED`      | true                      | Enable KVCached GPU sharing                                                                  |
-| `KVCACHED_AUTOPATCH`   | 1                         | Auto-patch vLLM for KVCached                                                                 |
+| `ENABLE_KVCACHED`      | true                      | Enable kvcached GPU sharing                                                                  |
+| `KVCACHED_AUTOPATCH`   | 1                         | Auto-patch vLLM for kvcached                                                                 |
 | `LOG_LEVEL`            | info                      | Pino log level                                                                               |
 | `LOG_ALL_REQUESTS`     | false                     | Force all routes to log at info level (debugging)                                            |
 | `HF_TOKEN`             | (none)                    | HuggingFace token for gated models                                                           |

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "sardeenz-backend"
 version = "0.1.0"
-description = "Python dependencies for sardeenz backend (vLLM, KVCached)"
+description = "Python dependencies for sardeenz backend (vLLM, kvcached)"
 requires-python = ">=3.12"
 
 # Base dependencies - installed in ALL environments (dev + Docker)

--- a/apps/backend/scripts/kvcache-stats.py
+++ b/apps/backend/scripts/kvcache-stats.py
@@ -7,15 +7,24 @@ segments in /dev/shm, mimicking the behavior of kvtop from the kvcached project.
 Output format (JSON array):
 [
   {
-    "ipc_name": "kvcached_mem_info",
+    "ipc_name": "kvcached_vllm_GPU0",
+    "gpu_indices": [0],
     "total_size": 6580224000,
     "used_size": 123456789,
     "prealloc_size": 987654321
+  },
+  {
+    "ipc_name": "kvcached_vllm_GPU0_GPU1",
+    "gpu_indices": [0, 1],
+    "total_size": 3290112000,
+    "used_size": 0,
+    "prealloc_size": 0
   }
 ]
 """
 
 import fcntl
+import re
 import json
 import mmap
 import os
@@ -33,6 +42,32 @@ DTYPE = np.int64
 N_FIELDS = 3
 SHM_SIZE = np.dtype(DTYPE).itemsize * N_FIELDS  # 24 bytes (3 x int64)
 
+# Pattern for per-GPU IPC segment names: kvcached_vllm_GPU{id} or kvcached_vllm_GPU{id1}_GPU{id2}
+GPU_SEGMENT_PATTERN = re.compile(r"^kvcached_vllm_GPU(\d+(?:_GPU\d+)*)$")
+
+
+def parse_gpu_indices(ipc_name: str) -> list[int] | None:
+    """Extract GPU indices from IPC segment name.
+
+    Args:
+        ipc_name: Name of the shared memory segment
+
+    Returns:
+        List of GPU indices [0], [0, 1], etc. or None for legacy/unknown segments
+
+    Examples:
+        'kvcached_vllm_GPU0' -> [0]
+        'kvcached_vllm_GPU0_GPU1' -> [0, 1]
+        'kvcached_vllm_GPU1_GPU2_GPU3' -> [1, 2, 3]
+        'kvcached_mem_info' -> None (legacy global segment)
+    """
+    match = GPU_SEGMENT_PATTERN.match(ipc_name)
+    if match:
+        # Split "0_GPU1_GPU2" into ["0", "1", "2"]
+        parts = match.group(1).split("_GPU")
+        return [int(p) for p in parts]
+    return None
+
 
 def read_mem_info(ipc_name: str) -> dict | None:
     """Read memory info from a single shared memory segment.
@@ -41,7 +76,8 @@ def read_mem_info(ipc_name: str) -> dict | None:
         ipc_name: Name of the shared memory segment file in /dev/shm
 
     Returns:
-        Dict with ipc_name, total_size, used_size, prealloc_size or None on error
+        Dict with ipc_name, gpu_indices, total_size, used_size, prealloc_size
+        or None on error. gpu_indices is None for legacy segments.
     """
     path = os.path.join(SHM_DIR, ipc_name)
     try:
@@ -55,6 +91,7 @@ def read_mem_info(ipc_name: str) -> dict | None:
                     arr = np.ndarray((N_FIELDS,), dtype=DTYPE, buffer=mm)
                     return {
                         "ipc_name": ipc_name,
+                        "gpu_indices": parse_gpu_indices(ipc_name),
                         "total_size": int(arr[0]),
                         "used_size": int(arr[1]),
                         "prealloc_size": int(arr[2]),

--- a/apps/backend/scripts/start-dev.sh
+++ b/apps/backend/scripts/start-dev.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# start-dev.sh - Development startup script with vLLM/KVCached environment setup
+# start-dev.sh - Development startup script with vLLM/kvcached environment setup
 #
 # This script:
-# 1. Creates a Python virtual environment with vLLM and KVCached (if not exists)
+# 1. Creates a Python virtual environment with vLLM and kvcached (if not exists)
 # 2. Validates the environment by testing Python imports
-# 3. Sets up environment variables for KVCached GPU memory sharing
+# 3. Sets up environment variables for kvcached GPU memory sharing
 # 4. Starts the backend development server
 #
 # Prerequisites:
@@ -136,7 +136,7 @@ prompt_user_action() {
             ;;
         3)
             echo "Skipping venv setup..."
-            echo "Warning: vLLM/KVCached features will not be available."
+            echo "Warning: vLLM/kvcached features will not be available."
             ;;
         4)
             echo "Exiting."
@@ -173,7 +173,7 @@ else
     echo "Python environment validated successfully."
 fi
 
-# Set KVCached environment variables
+# Set kvcached environment variables
 export ENABLE_KVCACHED=true
 export KVCACHED_AUTOPATCH=1
 export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
@@ -182,7 +182,7 @@ export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
 export PATH="$VENV_DIR/bin:$PATH"
 
 echo ""
-echo "KVCached environment configured:"
+echo "kvcached environment configured:"
 echo "  ENABLE_KVCACHED=$ENABLE_KVCACHED"
 echo "  KVCACHED_AUTOPATCH=$KVCACHED_AUTOPATCH"
 echo "  CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -34,7 +34,7 @@ export interface Config {
   vllmMaxInstances: number
   vllmStartupTimeout: number
 
-  // KVCached configuration
+  // kvcached configuration
   enableKvcached: boolean
   kvcachedAutopatch: boolean
 
@@ -125,7 +125,7 @@ export const config: Config = {
   vllmMaxInstances: getEnvInt('VLLM_MAX_INSTANCES', 10),
   vllmStartupTimeout: getEnvInt('VLLM_STARTUP_TIMEOUT', 1800000), // 30 minutes default
 
-  // KVCached configuration
+  // kvcached configuration
   enableKvcached: getEnvBool('ENABLE_KVCACHED', true),
   kvcachedAutopatch: getEnvBool('KVCACHED_AUTOPATCH', true),
 

--- a/apps/backend/src/routes/benchmarks.ts
+++ b/apps/backend/src/routes/benchmarks.ts
@@ -92,7 +92,7 @@ export default async function benchmarkRoutes(fastify: FastifyInstance) {
         }
       }
 
-      // Detect if KVCached is enabled
+      // Detect if kvcached is enabled
       const kvcachedEnabled = config.enableKvcached ?? false
 
       // Create the benchmark run

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -37,7 +37,7 @@ await fastify.register(import('@fastify/helmet'), {
       scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"], // React dev tools may need these
       styleSrc: ["'self'", "'unsafe-inline'"], // PatternFly uses inline styles
       imgSrc: ["'self'", 'data:', 'blob:'],
-      connectSrc: ["'self'"],
+      connectSrc: ["'self'", 'https://api.github.com'],
       fontSrc: ["'self'", 'data:'],
       objectSrc: ["'none'"],
       frameAncestors: ["'none'"],

--- a/apps/backend/src/services/memory-monitor.ts
+++ b/apps/backend/src/services/memory-monitor.ts
@@ -13,6 +13,7 @@ const __dirname = path.dirname(__filename)
 /** KVCache segment info from Python script (reads /dev/shm like kvtop) */
 interface KvcacheSegment {
   ipc_name: string
+  gpu_indices: number[] | null // GPU indices parsed from segment name (null for legacy segments)
   total_size: number // bytes
   used_size: number // bytes
   prealloc_size: number // bytes
@@ -220,33 +221,81 @@ export class MemoryMonitor {
         }
       }
 
-      // Build per-GPU response
-      const gpus: PerGpuMetrics[] = nvidiaSmiInfo.gpus.map((gpu) => ({
-        gpu_index: gpu.index,
-        name: gpu.name,
-        total_gb: gpu.memoryTotalMB / 1024,
-        used_gb: gpu.memoryUsedMB / 1024,
-        free_gb: (gpu.memoryTotalMB - gpu.memoryUsedMB) / 1024,
-        utilization_percent: parseFloat(gpu.gpuUtilization.replace('%', '')) || 0,
-        models: modelsByGpu.get(gpu.index) ?? [],
-      }))
+      // Sum model baselines per GPU (from memoryBaselineByGpu captured at model load)
+      const baselinesByGpu = new Map<number, number>() // gpuId -> total baseline GB
+      for (const instance of runningInstances) {
+        for (const [gpuIdStr, baselineGb] of Object.entries(instance.memoryBaselineByGpu ?? {})) {
+          const gpuId = parseInt(gpuIdStr)
+          baselinesByGpu.set(gpuId, (baselinesByGpu.get(gpuId) ?? 0) + baselineGb)
+        }
+      }
 
-      // Aggregate KVCache metrics
-      const kvcacheTotalBytes = kvcacheSegments.reduce((sum, s) => sum + s.total_size, 0)
-      const kvcacheUsedBytes = kvcacheSegments.reduce((sum, s) => sum + s.used_size, 0)
-      const kvcachePreallocBytes = kvcacheSegments.reduce((sum, s) => sum + s.prealloc_size, 0)
-      const kvcacheFreeBytes = Math.max(0, kvcacheTotalBytes - kvcacheUsedBytes - kvcachePreallocBytes)
+      // Map IPC segment usage (used/prealloc) to GPUs
+      // For multi-GPU segments (e.g., kvcached_vllm_GPU0_GPU1), split evenly across GPUs
+      const ipcUsageByGpu = new Map<number, { used_gb: number; prealloc_gb: number }>()
+      for (const segment of kvcacheSegments) {
+        if (segment.gpu_indices && segment.gpu_indices.length > 0) {
+          const gpuCount = segment.gpu_indices.length
+          const usedPerGpu = (segment.used_size / 1024 ** 3) / gpuCount
+          const preallocPerGpu = (segment.prealloc_size / 1024 ** 3) / gpuCount
 
-      const kvcache: KVCacheMetrics = {
-        total_gb: kvcacheTotalBytes / 1024 ** 3,
-        prealloc_gb: kvcachePreallocBytes / 1024 ** 3,
-        used_gb: kvcacheUsedBytes / 1024 ** 3,
-        free_gb: kvcacheFreeBytes / 1024 ** 3,
+          for (const gpuId of segment.gpu_indices) {
+            const existing = ipcUsageByGpu.get(gpuId) ?? { used_gb: 0, prealloc_gb: 0 }
+            ipcUsageByGpu.set(gpuId, {
+              used_gb: existing.used_gb + usedPerGpu,
+              prealloc_gb: existing.prealloc_gb + preallocPerGpu,
+            })
+          }
+        }
+      }
+
+      // Build per-GPU response with correct KVCache total calculation
+      const gpus: PerGpuMetrics[] = nvidiaSmiInfo.gpus.map((gpu) => {
+        const models = modelsByGpu.get(gpu.index) ?? []
+        const totalBaseline = baselinesByGpu.get(gpu.index) ?? 0
+        const ipcUsage = ipcUsageByGpu.get(gpu.index)
+
+        // Calculate "Other" processes memory = GPU used - sardeenz model memory
+        const sardeenzMemoryGb = models.reduce((sum, m) => sum + m.gpu_memory_gb, 0)
+        const otherProcessesGb = Math.max(0, gpu.memoryUsedMB / 1024 - sardeenzMemoryGb)
+
+        // KVCache Total = GPU Total - Model Baselines - Other Processes
+        // This is the correct calculation, NOT using the stale IPC segment total_size
+        const kvcacheTotalGb = Math.max(0,
+          gpu.memoryTotalMB / 1024 - totalBaseline - otherProcessesGb
+        )
+
+        // Build per-GPU KVCache metrics if there are any model baselines or IPC usage
+        const kvcache: KVCacheMetrics | undefined = (totalBaseline > 0 || ipcUsage) ? {
+          total_gb: kvcacheTotalGb,
+          prealloc_gb: ipcUsage?.prealloc_gb ?? 0,
+          used_gb: ipcUsage?.used_gb ?? 0,
+          free_gb: Math.max(0, kvcacheTotalGb - (ipcUsage?.used_gb ?? 0) - (ipcUsage?.prealloc_gb ?? 0)),
+        } : undefined
+
+        return {
+          gpu_index: gpu.index,
+          name: gpu.name,
+          total_gb: gpu.memoryTotalMB / 1024,
+          used_gb: gpu.memoryUsedMB / 1024,
+          free_gb: (gpu.memoryTotalMB - gpu.memoryUsedMB) / 1024,
+          utilization_percent: parseFloat(gpu.gpuUtilization.replace('%', '')) || 0,
+          models,
+          kvcache, // Per-GPU KVCache metrics with correct total calculation
+        }
+      })
+
+      // Global summary = sum of per-GPU metrics (for backward compatibility)
+      const globalKvcache: KVCacheMetrics = {
+        total_gb: gpus.reduce((sum, g) => sum + (g.kvcache?.total_gb ?? 0), 0),
+        prealloc_gb: gpus.reduce((sum, g) => sum + (g.kvcache?.prealloc_gb ?? 0), 0),
+        used_gb: gpus.reduce((sum, g) => sum + (g.kvcache?.used_gb ?? 0), 0),
+        free_gb: gpus.reduce((sum, g) => sum + (g.kvcache?.free_gb ?? 0), 0),
       }
 
       return {
         gpus,
-        kvcache,
+        kvcache: globalKvcache,
         total_system_free_gb: gpus.reduce((sum, g) => sum + g.free_gb, 0),
       }
     } catch (err) {

--- a/apps/backend/src/services/model-manager.ts
+++ b/apps/backend/src/services/model-manager.ts
@@ -59,6 +59,16 @@ function hasArg(args: string[], argName: string): boolean {
   return args.some((arg) => arg.split('=')[0].toLowerCase() === lowerArgName)
 }
 
+/**
+ * Build IPC segment name for kvcached based on GPU(s)
+ * Single GPU: kvcached_vllm_GPU0
+ * Multi-GPU (tensor parallel): kvcached_vllm_GPU0_GPU1
+ */
+function buildIpcSegmentName(gpuIds: number[]): string {
+  const sortedIds = [...gpuIds].sort((a, b) => a - b)
+  return `kvcached_vllm_GPU${sortedIds.join('_GPU')}`
+}
+
 export class ModelManager extends EventEmitter {
   private logger: Logger
   // Keyed by instance ID (UUID) for multi-instance support
@@ -74,7 +84,7 @@ export class ModelManager extends EventEmitter {
   /**
    * Launch a new model instance
    * Supports multiple instances of the same model (FR-004)
-   * GPU memory is managed by KVCached
+   * GPU memory is managed by kvcached
    */
   async launchModel(options: LaunchModelOptions): Promise<ModelInstance> {
     const {
@@ -98,8 +108,8 @@ export class ModelManager extends EventEmitter {
       tensorParallelSize
     )
 
-    // Determine KVCached status
-    // KVCached supports tensor parallelism as of Q2 2025
+    // Determine kvcached status
+    // kvcached supports tensor parallelism as of Q2 2025
     const enableKvcached = config.enableKvcached
 
     this.logger.info(
@@ -134,11 +144,12 @@ export class ModelManager extends EventEmitter {
       gpuIds: targetGpuIds,
       tensorParallelSize,
       kvcachedEnabled: enableKvcached,
+      memoryBaselineByGpu: {}, // Will be populated when model becomes ready
     }
 
     try {
       // Spawn vLLM process
-      // Note: GPU memory is managed by KVCached, no --gpu-memory-utilization flag needed
+      // Note: GPU memory is managed by kvcached, no --gpu-memory-utilization flag needed
       // Get HF token from runtime settings (may be from env or set via API)
       const hfToken = runtimeSettings.getHfToken()
 
@@ -165,16 +176,24 @@ export class ModelManager extends EventEmitter {
         baseArgs.push(`--tensor-parallel-size=${tensorParallelSize}`)
       }
 
-      // Only add prefix caching flag if KVCached is enabled
+      // Only add prefix caching flag if kvcached is enabled
       if (enableKvcached) {
-        baseArgs.push('--no-enable-prefix-caching') // Required for KVCached
+        baseArgs.push('--no-enable-prefix-caching') // Required for kvcached
       }
 
       // Append sanitized user-provided extra arguments (may include overrides)
       const allArgs = [...baseArgs, ...sanitizedExtraArgs]
 
+      // Build IPC segment name for kvcached
+      // Single GPU: kvcached_vllm_GPU0, Multi-GPU: kvcached_vllm_GPU0_GPU1
+      const kvcachedIpcName = enableKvcached ? buildIpcSegmentName(targetGpuIds) : undefined
+
       // Build and store the full launch command for debugging/reproduction
-      instance.launchCommand = `CUDA_VISIBLE_DEVICES=${targetGpuIds.join(',')} vllm ${allArgs.join(' ')}`
+      const envVars = [`CUDA_VISIBLE_DEVICES=${targetGpuIds.join(',')}`]
+      if (kvcachedIpcName) {
+        envVars.push(`KVCACHED_IPC_NAME=${kvcachedIpcName}`)
+      }
+      instance.launchCommand = `${envVars.join(' ')} vllm ${allArgs.join(' ')}`
 
       const proc = spawn('vllm', allArgs, {
         env: {
@@ -183,6 +202,7 @@ export class ModelManager extends EventEmitter {
           CUDA_VISIBLE_DEVICES: targetGpuIds.join(','), // GPU restriction
           ENABLE_KVCACHED: enableKvcached ? 'true' : 'false',
           KVCACHED_AUTOPATCH: config.kvcachedAutopatch && enableKvcached ? '1' : '0',
+          ...(kvcachedIpcName ? { KVCACHED_IPC_NAME: kvcachedIpcName } : {}), // Per-GPU IPC segment
           ...(hfToken ? { HF_TOKEN: hfToken } : {}),
         },
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -394,6 +414,19 @@ export class ModelManager extends EventEmitter {
             'No matching processes found in nvidia-smi output'
           )
         }
+        // Capture memory baseline per GPU for KVCache calculation
+        // This baseline represents the idle memory footprint before any inference requests
+        const memoryByGpu: Record<number, number> = {}
+        for (const proc of gpuInfo.processes) {
+          if (allPids.has(proc.pid) && instance.gpuIds.includes(proc.gpu)) {
+            memoryByGpu[proc.gpu] = (memoryByGpu[proc.gpu] ?? 0) + proc.gpuMemoryMB / 1024
+          }
+        }
+        instance.memoryBaselineByGpu = memoryByGpu
+        this.logger.info(
+          { instanceId, modelPath, memoryBaselineByGpu: memoryByGpu },
+          'Captured memory baseline per GPU'
+        )
       } catch (err) {
         this.logger.warn({ modelPath, instanceId, err }, 'Failed to get GPU memory from nvidia-smi')
       }
@@ -545,7 +578,7 @@ export class ModelManager extends EventEmitter {
 
     try {
       // Use SIGKILL to bypass Python signal handlers that would delete
-      // the shared KVCached IPC segment (kvcached_mem_info)
+      // the shared kvcached IPC segment (kvcached_mem_info)
       await killProcessImmediate(proc)
 
       // Explicitly kill EngineCore if tracked (may not be a descendant of the main process)
@@ -676,7 +709,7 @@ export class ModelManager extends EventEmitter {
   }
 
   /**
-   * Get IPC segment name for KVCached
+   * Get IPC segment name for kvcached
    * Include instance ID suffix for uniqueness when running multiple instances
    */
   private getIpcSegmentName(modelPath: string, instanceId: string): string {
@@ -692,21 +725,61 @@ export class ModelManager extends EventEmitter {
   }
 
   /**
-   * Delete the shared KVCached IPC segment
+   * Delete all GPU-specific kvcached IPC segments
    * Called only during server shutdown when all models are unloaded
    */
   private async deleteSharedIpcSegment(): Promise<void> {
-    const segmentName = 'kvcached_mem_info'
+    // Collect unique IPC segment names from currently loaded models
+    const segmentNames = new Set<string>()
+    for (const model of this.listModels()) {
+      const name = buildIpcSegmentName(model.gpuIds)
+      segmentNames.add(name)
+    }
+
+    // Also try common single-GPU segments (0-7) in case models were already unloaded
+    for (let i = 0; i < 8; i++) {
+      segmentNames.add(`kvcached_vllm_GPU${i}`)
+    }
+
+    // Try common multi-GPU combinations for tensor-parallel models
+    // Common 2-GPU pairs
+    for (let i = 0; i < 8; i += 2) {
+      segmentNames.add(`kvcached_vllm_GPU${i}_GPU${i + 1}`)
+    }
+    // Common 4-GPU groups
+    segmentNames.add('kvcached_vllm_GPU0_GPU1_GPU2_GPU3')
+    segmentNames.add('kvcached_vllm_GPU4_GPU5_GPU6_GPU7')
+    // 8-GPU group
+    segmentNames.add('kvcached_vllm_GPU0_GPU1_GPU2_GPU3_GPU4_GPU5_GPU6_GPU7')
+
+    // Delete each segment
+    for (const segmentName of segmentNames) {
+      try {
+        const proc = spawn('kvctl', ['delete', segmentName])
+        await new Promise<void>((resolve) => {
+          proc.on('exit', (code) => {
+            if (code === 0) {
+              this.logger.info({ segmentName }, 'Deleted kvcached IPC segment')
+            }
+            resolve()
+          })
+          proc.on('error', () => resolve())
+        })
+      } catch {
+        // Non-critical, segment may not exist
+        this.logger.debug({ segmentName }, 'Failed to delete IPC segment (non-critical)')
+      }
+    }
+
+    // Also try deleting the legacy global segment for backward compatibility
     try {
-      const proc = spawn('kvctl', ['delete', segmentName])
+      const proc = spawn('kvctl', ['delete', 'kvcached_mem_info'])
       await new Promise<void>((resolve) => {
         proc.on('exit', () => resolve())
-        proc.on('error', () => resolve()) // Ignore errors
+        proc.on('error', () => resolve())
       })
-      this.logger.info('Deleted shared KVCached IPC segment')
     } catch {
-      // Non-critical, segment may not exist
-      this.logger.debug({ segmentName }, 'Failed to delete shared IPC segment (non-critical)')
+      // Ignore - legacy segment may not exist
     }
   }
 
@@ -807,7 +880,7 @@ export class ModelManager extends EventEmitter {
     // Clean up log buffer
     processLogBuffer.cleanup()
 
-    // Delete the shared KVCached IPC segment now that all models are unloaded
+    // Delete the shared kvcached IPC segment now that all models are unloaded
     await this.deleteSharedIpcSegment()
   }
 

--- a/apps/backend/src/utils/process.ts
+++ b/apps/backend/src/utils/process.ts
@@ -106,7 +106,7 @@ export async function killProcessGracefully(
 
 /**
  * Kill a process and all its descendants with SIGKILL (bypasses signal handlers)
- * Use this for vLLM/KVCached processes where Python signal handlers would
+ * Use this for vLLM/kvcached processes where Python signal handlers would
  * delete the shared IPC segment, breaking other running models.
  *
  * SIGKILL doesn't propagate to children, so we must explicitly kill all

--- a/apps/frontend/src/components/GpuMemoryPanel.tsx
+++ b/apps/frontend/src/components/GpuMemoryPanel.tsx
@@ -103,10 +103,12 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000 }: GpuMemoryPanel
     return gpu || memoryData.gpus[0]
   }, [memoryData, activeGpuIndex])
 
-  // Build KVCache bar data
+  // Build KVCache bar data from per-GPU metrics
   const kvcacheData = useMemo(() => {
-    if (!memoryData) return []
-    const { kvcache } = memoryData
+    // Use per-GPU kvcache from selected GPU (if available)
+    const kvcache = selectedGpu?.kvcache
+    if (!kvcache || kvcache.total_gb === 0) return []
+
     return [
       {
         id: 'KVCache',
@@ -115,7 +117,7 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000 }: GpuMemoryPanel
         Free: Number(kvcache.free_gb.toFixed(2)),
       },
     ]
-  }, [memoryData])
+  }, [selectedGpu])
 
   // Build GPU bar data with per-model breakdown for selected GPU
   const gpuData = useMemo(() => {
@@ -297,46 +299,59 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000 }: GpuMemoryPanel
             </Flex>
           </FlexItem>
 
-          {/* KVCache Memory Bar - Column 2 */}
+          {/* KVCache Memory Bar - Column 2 (Per-GPU) */}
           <FlexItem flex={{ default: 'flex_1' }}>
             <Content component="small" style={{ color: 'var(--pf-t--global--text--color--subtle)' }}>
-              KVCache Memory (Shared Pool) —{' '}
-              {formatGb(memoryData?.kvcache.used_gb ?? 0)} / {formatGb(memoryData?.kvcache.total_gb ?? 0)}
+              {memoryData && memoryData.gpus.length > 1 && `GPU ${selectedGpu?.gpu_index} `}
+              KVCache Memory —{' '}
+              {selectedGpu?.kvcache && selectedGpu.kvcache.total_gb > 0
+                ? `${formatGb(selectedGpu.kvcache.used_gb)} / ${formatGb(selectedGpu.kvcache.total_gb)}`
+                : 'No KVCache active'}
             </Content>
-            <div style={{ height: '40px', marginTop: 'var(--pf-t--global--spacer--xs)' }}>
-              <ResponsiveBar
-                data={kvcacheData}
-                keys={['Prealloc', 'Used', 'Free']}
-                indexBy="id"
-                layout="horizontal"
-                margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
-                padding={0}
-                colors={(bar) => KVCACHE_COLORS[bar.id as keyof typeof KVCACHE_COLORS] || '#ccc'}
-                borderRadius={4}
-                enableLabel={false}
-                enableGridY={false}
-                enableGridX={false}
-                axisTop={null}
-                axisRight={null}
-                axisBottom={null}
-                axisLeft={null}
-                theme={getTooltipTheme()}
-              />
-            </div>
-            <Flex gap={{ default: 'gapSm' }} style={{ marginTop: 'var(--pf-t--global--spacer--xs)' }}>
-              <FlexItem>
-                <span style={{ color: KVCACHE_COLORS.Prealloc }}>●</span>{' '}
-                <Content component="small">Prealloc ({formatGb(memoryData?.kvcache.prealloc_gb ?? 0)})</Content>
-              </FlexItem>
-              <FlexItem>
-                <span style={{ color: KVCACHE_COLORS.Used }}>●</span>{' '}
-                <Content component="small">Used ({formatGb(memoryData?.kvcache.used_gb ?? 0)})</Content>
-              </FlexItem>
-              <FlexItem>
-                <span style={{ color: KVCACHE_COLORS.Free }}>●</span>{' '}
-                <Content component="small">Free ({formatGb(memoryData?.kvcache.free_gb ?? 0)})</Content>
-              </FlexItem>
-            </Flex>
+            {selectedGpu?.kvcache && selectedGpu.kvcache.total_gb > 0 ? (
+              <>
+                <div style={{ height: '40px', marginTop: 'var(--pf-t--global--spacer--xs)' }}>
+                  <ResponsiveBar
+                    data={kvcacheData}
+                    keys={['Prealloc', 'Used', 'Free']}
+                    indexBy="id"
+                    layout="horizontal"
+                    margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+                    padding={0}
+                    colors={(bar) => KVCACHE_COLORS[bar.id as keyof typeof KVCACHE_COLORS] || '#ccc'}
+                    borderRadius={4}
+                    enableLabel={false}
+                    enableGridY={false}
+                    enableGridX={false}
+                    axisTop={null}
+                    axisRight={null}
+                    axisBottom={null}
+                    axisLeft={null}
+                    theme={getTooltipTheme()}
+                  />
+                </div>
+                <Flex gap={{ default: 'gapSm' }} style={{ marginTop: 'var(--pf-t--global--spacer--xs)' }}>
+                  <FlexItem>
+                    <span style={{ color: KVCACHE_COLORS.Prealloc }}>●</span>{' '}
+                    <Content component="small">Prealloc ({formatGb(selectedGpu.kvcache.prealloc_gb)})</Content>
+                  </FlexItem>
+                  <FlexItem>
+                    <span style={{ color: KVCACHE_COLORS.Used }}>●</span>{' '}
+                    <Content component="small">Used ({formatGb(selectedGpu.kvcache.used_gb)})</Content>
+                  </FlexItem>
+                  <FlexItem>
+                    <span style={{ color: KVCACHE_COLORS.Free }}>●</span>{' '}
+                    <Content component="small">Free ({formatGb(selectedGpu.kvcache.free_gb)})</Content>
+                  </FlexItem>
+                </Flex>
+              </>
+            ) : (
+              <div style={{ height: '40px', marginTop: 'var(--pf-t--global--spacer--xs)', display: 'flex', alignItems: 'center' }}>
+                <Content component="small" style={{ fontStyle: 'italic', color: 'var(--pf-t--global--text--color--subtle)' }}>
+                  No models with kvcached enabled on this GPU
+                </Content>
+              </div>
+            )}
           </FlexItem>
         </Flex>
 

--- a/apps/frontend/src/components/LoadModelDialog.tsx
+++ b/apps/frontend/src/components/LoadModelDialog.tsx
@@ -702,7 +702,7 @@ export function LoadModelDialog({
                               title="Tensor Parallelism"
                               style={{ marginTop: 'var(--pf-t--global--spacer--sm)' }}
                             >
-                              Tensor parallelism with KVCached is a recent feature. Results may vary.
+                              Tensor parallelism with kvcached is a recent feature. Results may vary.
                             </Alert>
                           </div>
                         )}

--- a/apps/frontend/src/components/benchmark/BenchmarkProgress.tsx
+++ b/apps/frontend/src/components/benchmark/BenchmarkProgress.tsx
@@ -99,7 +99,15 @@ export function BenchmarkProgress({ benchmarkId, onComplete, onCancel }: Benchma
 
   const connectToSSE = useCallback(() => {
     const baseUrl = import.meta.env.VITE_API_BASE_URL || ''
-    const eventSource = new EventSource(`${baseUrl}/api/benchmarks/${benchmarkId}/events`)
+    // Add auth token for SSE (EventSource can't send Authorization header)
+    const token = apiClient.getAuthToken()
+    const params = new URLSearchParams()
+    if (token) {
+      params.set('token', token)
+    }
+    const queryString = params.toString()
+    const url = `${baseUrl}/api/benchmarks/${benchmarkId}/events${queryString ? `?${queryString}` : ''}`
+    const eventSource = new EventSource(url)
 
     eventSource.onopen = () => {
       setIsConnected(true)

--- a/apps/frontend/src/pages/ModelBenchmark.tsx
+++ b/apps/frontend/src/pages/ModelBenchmark.tsx
@@ -22,6 +22,7 @@ import {
 import type { BenchmarkFormConfig, InitialBenchmarkConfig } from '../components/benchmark'
 import { apiClient, extractErrorMessage } from '../services/api'
 import { useAuth } from '../contexts/AuthContext'
+import { useNotifications } from '../contexts/NotificationContext'
 
 /** Performance tab view state machine */
 type PerformanceView = 'list' | 'form' | 'running' | 'results'
@@ -32,6 +33,7 @@ type PerformanceView = 'list' | 'form' | 'running' | 'results'
  */
 function ModelBenchmark() {
   const { canWrite } = useAuth()
+  const { addNotification } = useNotifications()
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0)
 
   // Performance tab state
@@ -119,12 +121,15 @@ function ModelBenchmark() {
       setPerformanceView('running')
     } catch (err) {
       console.error('Failed to start benchmark:', err)
-      // Error is shown via alert in the form
-      throw new Error(extractErrorMessage(err))
+      addNotification({
+        title: 'Failed to start benchmark',
+        description: extractErrorMessage(err),
+        variant: 'danger',
+      })
     } finally {
       setIsSubmitting(false)
     }
-  }, [])
+  }, [addNotification])
 
   const handleBenchmarkComplete = () => {
     setPerformanceView('results')

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -18,10 +18,14 @@ This step is only required if you want to use your own image instead of the one 
 
 ```bash
 # Build the unified container image
-docker build -f docker/Dockerfile.unified -t quay.io/your-org/sardeenz:latest .
+make build VERSION=x.y.z
 
 # Push to your container registry
-docker push quay.io/your-org/sardeenz:latest
+make push VERSION=x.y.z
+
+# Or manually with podman:
+podman build -f docker/Containerfile -t quay.io/rh-aiservices-bu/sardeenz:x.y.z .
+podman push quay.io/rh-aiservices-bu/sardeenz:x.y.z
 ```
 
 ### 2. Create Namespace
@@ -158,8 +162,8 @@ oc get route sardeenz -n sardeenz -o jsonpath='{.spec.host}'
 | `ADMIN_USERNAME` | `admin` | Username for simple auth mode |
 | `JWT_EXPIRATION_HOURS` | `8` | JWT token lifetime in hours |
 | `API_BASE_URL` | - | Base URL for OAuth callbacks (your route URL) |
-| `ENABLE_KVCACHED` | `true` | Enable KVCached GPU memory sharing |
-| `KVCACHED_AUTOPATCH` | `1` | Auto-patch vLLM for KVCached |
+| `ENABLE_KVCACHED` | `true` | Enable kvcached GPU memory sharing |
+| `KVCACHED_AUTOPATCH` | `1` | Auto-patch vLLM for kvcached |
 | `VLLM_BASE_PORT` | `12346` | Starting port for vLLM instances |
 | `VLLM_MAX_INSTANCES` | `10` | Maximum concurrent model instances |
 | `VLLM_STARTUP_TIMEOUT` | `1800000` | Model startup timeout in ms (30 min default) |
@@ -625,7 +629,7 @@ oc logs deployment/sardeenz | grep -i error
 **Common causes:**
 - Insufficient GPU memory → Unload other models or use smaller models
 - Model not cached → First download takes longer; ensure HuggingFace cache PVC is configured if downloading models
-- KVCached not enabled → Verify `ENABLE_KVCACHED=true` in ConfigMap
+- kvcached not enabled → Verify `ENABLE_KVCACHED=true` in ConfigMap
 
 ### Performance Issues
 
@@ -637,7 +641,7 @@ oc adm top pod -l app=sardeenz
 
 **Optimize:**
 - Increase CPU/memory limits in `deployment.yaml`
-- Enable KVCached for better GPU memory sharing
+- Enable kvcached for better GPU memory sharing
 - Use faster storage class for PVC
 - Adjust `VLLM_MAX_INSTANCES` based on available GPU memory
 
@@ -712,7 +716,7 @@ oc apply -k deployment/overlays/prod/
 ## Additional Resources
 
 - [vLLM Documentation](https://docs.vllm.ai/)
-- [KVCached Guide](../docs/kvcached/README.md)
+- [kvcached Guide](../docs/kvcached/README.md)
 - [API Documentation](../docs/api-guide.md)
 - [Architecture Overview](../docs/architecture.md)
 - [OpenShift GPU Operator](https://docs.openshift.com/container-platform/latest/architecture/nvidia-gpu-architecture-overview.html)

--- a/deployment/configmap.yaml
+++ b/deployment/configmap.yaml
@@ -37,7 +37,7 @@ data:
   API_BASE_URL: ""
 
   # =============================================================================
-  # KVCached Configuration
+  # kvcached Configuration
   # =============================================================================
   ENABLE_KVCACHED: "true"
   KVCACHED_AUTOPATCH: "1"

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -141,7 +141,7 @@ spec:
                   optional: true
 
             # =================================================================
-            # KVCached Configuration (from ConfigMap)
+            # kvcached Configuration (from ConfigMap)
             # =================================================================
             - name: ENABLE_KVCACHED
               valueFrom:

--- a/docker/Containerfile
+++ b/docker/Containerfile
@@ -1,6 +1,6 @@
 # =============================================================================
 # Multi-stage Dockerfile for Sardeenz
-# Based on vLLM CUDA image (UBI/RHEL) with Node.js 22 and KVCached
+# Based on vLLM CUDA image (UBI/RHEL) with Node.js 22 and kvcached
 # =============================================================================
 
 # =============================================================================
@@ -15,11 +15,11 @@ RUN microdnf -y update \
     && rm -rf /var/cache/yum/*
 
 # =============================================================================
-# Stage 1: KVCached Builder (vllm-base + CUDA devel + dependencies)
+# Stage 1: kvcached Builder (vllm-base + CUDA devel + dependencies)
 # =============================================================================
 FROM vllm-base AS kvcached-builder
 
-ARG KVCACHED_VERSION=0.1.2
+ARG KVCACHED_VERSION=main
 
 ENV NV_CUDA_LIB_VERSION=12.8.1-1
 ENV NV_CUDA_CUDART_DEV_VERSION=12.8.90-1
@@ -31,6 +31,7 @@ ENV NV_CUDA_NSIGHT_COMPUTE_VERSION=12.8.1-1
 
 # Install CUDA build dependencies (minimal set for wheel compilation)
 RUN microdnf install -y \
+    git \
     cuda-command-line-tools-12-8-${NV_CUDA_LIB_VERSION} \
     cuda-libraries-devel-12-8-${NV_CUDA_LIB_VERSION} \
     cuda-minimal-build-12-8-${NV_CUDA_LIB_VERSION} \
@@ -43,11 +44,14 @@ RUN microdnf install -y \
     && microdnf clean all \
     && rm -rf /var/cache/yum/*
 
-# Build KVCached wheel with CUDA support
+# Clone and build kvcached from source (supports branch or tag)
 WORKDIR /build
-RUN pip3.12 wheel kvcached==${KVCACHED_VERSION} \
-    --no-build-isolation \
-    --wheel-dir /wheels
+RUN git clone --depth 1 --branch ${KVCACHED_VERSION} \
+        https://github.com/ovg-project/kvcached.git \
+    && cd kvcached \
+    && pip3.12 wheel . \
+        --no-build-isolation \
+        --wheel-dir /wheels
 
 # =============================================================================
 # Stage 2: Runtime Dependencies
@@ -124,6 +128,9 @@ COPY --from=builder /app/apps/backend/scripts ./apps/backend/scripts
 # Copy frontend (static files only)
 COPY --from=builder /app/apps/frontend/dist ./apps/frontend/dist
 
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Environment variables
 ENV NODE_ENV=production
 ENV PORT=3000
@@ -131,16 +138,15 @@ ENV HOST=0.0.0.0
 ENV LOG_LEVEL=info
 ENV ENABLE_KVCACHED=true
 ENV KVCACHED_AUTOPATCH=1
+ENV HF_HUB_OFFLINE=0
 
 # OpenShift arbitrary UID support - redirect cache to writable location
 # vLLM and FlashInfer need writable cache directories; /home/vllm is not writable
 ENV HOME=/opt/app-root/src
 ENV XDG_CACHE_HOME=/opt/app-root/src/.cache
+ENV HF_HOME=/opt/app-root/src/.cache/huggingface
 ENV FLASHINFER_WORKSPACE_DIR=/opt/app-root/src/.cache/flashinfer
 
 EXPOSE 3000
-
-COPY docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   sardeenz:
     build:
       context: ..
-      dockerfile: docker/Dockerfile.unified
+      dockerfile: docker/Containerfile
     container_name: sardeenz
     ports:
       - "3000:3000"  # Backend API

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 | Resource                                                        | Description                                            |
 | --------------------------------------------------------------- | ------------------------------------------------------ |
 | [**Development Guide**](./development/README.md)                | Getting started with local development                 |
-| [**GPU Setup**](./dev-setup.md)                                 | GPU environment setup (vLLM, KVCached, uv)             |
+| [**GPU Setup**](./dev-setup.md)                                 | GPU environment setup (vLLM, kvcached, uv)             |
 | [**PatternFly 6 Guide**](./development/pf6-guide/README.md)     | Complete UI development guide with PatternFly 6        |
 | [**Frontend API Client**](./development/frontend-api-client.md) | API client integration for the frontend                |
 
@@ -27,7 +27,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 
 | Resource                                                 | Description                                                |
 | -------------------------------------------------------- | ---------------------------------------------------------- |
-| [**KVCached**](./kvcached/)                              | GPU memory sharing documentation and setup guides          |
+| [**kvcached**](./kvcached/)                              | GPU memory sharing documentation and setup guides          |
 | [**Specifications**](../specs/001-multi-model-platform/) | Design specifications, planning documents, and data models |
 | [**Changelog**](../CHANGELOG.md)                         | Project change history                                     |
 
@@ -45,7 +45,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 
 3. **Develop Locally**
    - Follow the [Development Guide](./development/README.md)
-   - See [GPU Setup](./dev-setup.md) for vLLM/KVCached configuration
+   - See [GPU Setup](./dev-setup.md) for vLLM/kvcached configuration
 
 4. **Use the APIs**
    - Explore [api-guide.md](./api-guide.md) for API examples
@@ -92,7 +92,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 
 - [API Guide: Controller API](./api-guide.md#controller-api) - Load/unload models
 - [API Guide: Proxy API](./api-guide.md#proxy-api) - Inference requests (OpenAI-compatible)
-- [KVCached Documentation](./kvcached/) - GPU memory sharing for multi-model hosting
+- [kvcached Documentation](./kvcached/) - GPU memory sharing for multi-model hosting
 - [Architecture: Memory Management](./architecture.md#memory-management) - GPU allocation strategy
 
 **Supported Models:**
@@ -141,14 +141,14 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 | Document                         | Topics Covered                                                                                                   |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | [deployment.md](./deployment.md) | Container build, Docker Compose, OpenShift deployment, configuration, health checks, monitoring, troubleshooting |
-| [kvcached/](./kvcached/)         | KVCached installation, configuration, memory segment management                                                  |
+| [kvcached/](./kvcached/)         | kvcached installation, configuration, memory segment management                                                  |
 
 ### Development Guides
 
 | Document                                                                   | Topics Covered                                                                |
 | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | [development/README.md](./development/README.md)                           | Local setup, prerequisites, project structure, development commands           |
-| [dev-setup.md](./dev-setup.md)                                             | GPU development environment, vLLM setup, KVCached configuration               |
+| [dev-setup.md](./dev-setup.md)                                             | GPU development environment, vLLM setup, kvcached configuration               |
 | [development/pf6-guide/](./development/pf6-guide/README.md)                | PatternFly 6 components, styling standards, testing patterns, troubleshooting |
 | [development/frontend-api-client.md](./development/frontend-api-client.md) | Axios setup, API client patterns, error handling                              |
 
@@ -188,9 +188,9 @@ The **Proxy API** provides a unified inference endpoint:
 
 **Compatible with:** OpenAI Python SDK, OpenAI JavaScript SDK, curl
 
-### KVCached
+### kvcached
 
-**KVCached** is a GPU memory sharing tool that enables multiple vLLM instances to coexist on a single GPU:
+**kvcached** is a GPU memory sharing tool that enables multiple vLLM instances to coexist on a single GPU:
 
 - **IPC segments** for shared KV cache
 - **Memory limits** enforced per model
@@ -240,7 +240,7 @@ See [kvcached/README.md](./kvcached/README.md) for detailed setup instructions.
 <details>
 <summary><strong>Can I use this with non-NVIDIA GPUs?</strong></summary>
 
-No, vLLM and KVCached require NVIDIA GPUs with CUDA support. AMD GPUs (ROCm) are not currently supported.
+No, vLLM and kvcached require NVIDIA GPUs with CUDA support. AMD GPUs (ROCm) are not currently supported.
 
 </details>
 
@@ -265,7 +265,7 @@ It depends on your GPU memory. Example on a 24GB GPU:
 - 2-3 medium models (7B params)
 - 1 large model (13B+ params) + 1-2 small models
 
-Use KVCached to optimize memory sharing.
+Use kvcached to optimize memory sharing.
 
 </details>
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -284,7 +284,7 @@ When authenticated with the `admin-readonly` role, the frontend displays visual 
 | `model_path`           | string   | Yes      | Model identifier (HuggingFace path or local path)                                |
 | `max_tokens`           | number   | No       | Maximum context length (default: model's max)                                    |
 | `gpu_ids`              | number[] | No       | GPU indices to use. If omitted, auto-selects GPU(s) with most free memory        |
-| `tensor_parallel_size` | number   | No       | Number of GPUs for tensor parallelism (default: 1). KVCached is disabled when >1 |
+| `tensor_parallel_size` | number   | No       | Number of GPUs for tensor parallelism (default: 1). kvcached is disabled when >1 |
 | `extra_args`           | string[] | No       | Additional vLLM CLI arguments                                                    |
 
 **Response (202 Accepted):**
@@ -426,8 +426,25 @@ curl -H "Authorization: Bearer $TOKEN" \
       "kv_cache_per_request_mib": 156.23,
       "max_model_len": 4096
     },
+    "memory_baseline_by_gpu": {
+      "0": 1.22
+    },
     "launch_command": "python -m vllm.entrypoints.openai.api_server --model meta-llama/Llama-3.2-1B --port 5001 ..."
   }
+}
+```
+
+**Memory Baseline Field:**
+
+| Field                    | Type                      | Description                                                        |
+| ------------------------ | ------------------------- | ------------------------------------------------------------------ |
+| `memory_baseline_by_gpu` | `Record<number, number>`  | Memory footprint per GPU in GB, captured when model becomes ready. Used for KVCache total calculation. |
+
+For tensor-parallel models, baselines are captured on each GPU:
+```json
+"memory_baseline_by_gpu": {
+  "0": 8.5,
+  "1": 8.5
 }
 ```
 
@@ -712,7 +729,13 @@ Returns per-GPU memory breakdown for multi-GPU systems.
           "gpu_memory_gb": 1.22,
           "color": "#0066CC"
         }
-      ]
+      ],
+      "kvcache": {
+        "total_gb": 12.5,
+        "prealloc_gb": 2.0,
+        "used_gb": 3.5,
+        "free_gb": 7.0
+      }
     },
     {
       "gpu_index": 1,
@@ -733,6 +756,22 @@ Returns per-GPU memory breakdown for multi-GPU systems.
   "total_system_free_gb": 27.5
 }
 ```
+
+**Per-GPU KVCache Metrics:**
+
+Each GPU with loaded models includes a `kvcache` object with per-GPU KVCache metrics:
+
+| Field                    | Description                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| `gpus[].kvcache`         | Per-GPU KVCache metrics (undefined if no models loaded on this GPU)                        |
+| `gpus[].kvcache.total_gb` | KVCache pool size = GPU Total - Model Baselines - Other Processes                         |
+| `gpus[].kvcache.used_gb` | Currently active KVCache memory (from IPC segment)                                         |
+| `gpus[].kvcache.prealloc_gb` | Pre-allocated but not active memory (from IPC segment)                                 |
+| `gpus[].kvcache.free_gb` | Available KVCache memory for new allocations                                               |
+
+The KVCache total is calculated dynamically as: `GPU Total - Model Baselines - Other Processes`. This replaces the old approach of reading a stale `total_size` from the IPC segment.
+
+**Note:** For tensor-parallel models spanning multiple GPUs, KVCache usage is split evenly across participating GPUs.
 
 ## GPU API
 
@@ -1492,7 +1531,9 @@ data: {"scenario_id":"uuid","metrics":{"ttft_avg":45.2,"tps_avg":156.8,...}}
 **Example (JavaScript):**
 
 ```javascript
-const eventSource = new EventSource('/api/benchmarks/550e8400-e29b-41d4-a716-446655440000/events')
+// Note: EventSource cannot send Authorization headers, so pass JWT as query parameter
+const token = getAuthToken() // Retrieve your JWT token
+const eventSource = new EventSource(`/api/benchmarks/550e8400-e29b-41d4-a716-446655440000/events?token=${token}`)
 
 eventSource.addEventListener('scenario:progress', (event) => {
   const data = JSON.parse(event.data)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ This document provides a detailed overview of the Sardeenz architecture, design 
 Sardeenz is a multi-model management platform designed to:
 1. **Dynamically load/unload** multiple LLM instances without downtime
 2. **Route inference requests** to the appropriate model via a unified proxy
-3. **Share GPU memory** efficiently across multiple models using KVCached
+3. **Share GPU memory** efficiently across multiple models using kvcached
 4. **Monitor and manage** resources through a web-based dashboard
 
 ### High-Level Architecture
@@ -51,11 +51,11 @@ Sardeenz is a multi-model management platform designed to:
 │  │   GPU 0      │  │   GPU 0      │  │  GPU 0-1 TP  │      │
 │  └──────────────┘  └──────────────┘  └──────────────┘      │
 └───────────┬─────────────────────────────────────────────────┘
-            │ KVCached IPC shared memory (single-GPU models)
+            │ kvcached IPC shared memory (single-GPU models)
             ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                   GPU Memory (CUDA)                         │
-│  • Shared KV cache segments (via KVCached)                  │
+│  • Shared KV cache segments (via kvcached)                  │
 │  • Model weights (per-GPU or tensor parallel)               │
 │  • Compute kernels                                          │
 └─────────────────────────────────────────────────────────────┘
@@ -95,7 +95,7 @@ Sardeenz is a multi-model management platform designed to:
 | Component | Technology | Version | Purpose |
 |-----------|-----------|---------|---------|
 | **Inference Engine** | vLLM | 0.11.0 | OpenAI-compatible LLM serving |
-| **Memory Sharing** | KVCached | Latest | GPU memory IPC for multi-model |
+| **Memory Sharing** | kvcached | Latest | GPU memory IPC for multi-model |
 | **Container Base** | CUDA | 12.x | NVIDIA GPU support |
 | **Python Runtime** | Python | 3.12 | vLLM dependencies |
 | **Orchestration** | OpenShift/K8s | 4.x+ | Container deployment platform |
@@ -232,8 +232,8 @@ python -m vllm.entrypoints.openai.api_server \
 ```
 
 **Environment Variables:**
-- `ENABLE_KVCACHED=true` - Enable KVCached memory sharing
-- `KVCACHED_AUTOPATCH=1` - Auto-patch vLLM for KVCached
+- `ENABLE_KVCACHED=true` - Enable kvcached memory sharing
+- `KVCACHED_AUTOPATCH=1` - Auto-patch vLLM for kvcached
 - `CUDA_VISIBLE_DEVICES=0` - GPU device assignment
 
 **Lifecycle States:**
@@ -316,7 +316,7 @@ interface BenchmarkRun {
   name?: string;                   // Optional run name
   status: 'pending' | 'running' | 'completed' | 'cancelled' | 'failed';
   mode: 'isolated' | 'contention'; // Execution mode
-  kvcachedEnabled: boolean;        // System KVCached status
+  kvcachedEnabled: boolean;        // System kvcached status
   createdAt: string;               // ISO timestamp
   startedAt?: string;
   completedAt?: string;
@@ -378,7 +378,7 @@ interface MemoryProfile {
   weightsMemoryGib: number;        // Model weights
   cudaGraphsGib: number;           // CUDA graph capture
   overheadMemoryGib: number;       // Other overhead
-  kvCacheAvailableGib: number;     // Available KV cache (deprecated with KVCached)
+  kvCacheAvailableGib: number;     // Available KV cache (deprecated with kvcached)
   kvCachePerRequestMib?: number;   // Estimated per-request KV cache
 
   // GPU context
@@ -397,7 +397,7 @@ interface MemoryProfile {
 
 ### Why Direct Subprocess Management?
 
-**Problem:** KVCached Controller requires restart to change model configuration, causing unacceptable downtime.
+**Problem:** kvcached Controller requires restart to change model configuration, causing unacceptable downtime.
 
 **Solution:** Node.js backend manages individual vLLM processes directly.
 
@@ -446,28 +446,42 @@ If health check fails 3 consecutive times, mark instance as `failed`.
 
 ## Memory Management
 
-### KVCached Integration
+### kvcached Integration
 
-**KVCached** enables multiple vLLM instances to share GPU memory via IPC segments.
+**kvcached** enables multiple vLLM instances to share GPU memory via per-GPU IPC segments.
 
 **Memory Segment Naming:**
+
+Each GPU (or GPU-pair for tensor-parallel models) gets its own IPC segment:
 ```
-VLLM_META_LLAMA_LLAMA_3_2_1B  # Derived from model path
+kvcached_vllm_GPU0           # Single GPU model on GPU 0
+kvcached_vllm_GPU1           # Single GPU model on GPU 1
+kvcached_vllm_GPU0_GPU1      # Tensor-parallel model on GPUs 0 and 1
 ```
 
-**Memory Limit Enforcement:**
-```bash
-kvctl limit VLLM_META_LLAMA_LLAMA_3_2_1B 8GB
-```
+The segment name is set automatically via the `KVCACHED_IPC_NAME` environment variable based on the model's GPU assignment.
 
-**Memory Cleanup on Unload:**
-```bash
-kvctl delete VLLM_META_LLAMA_LLAMA_3_2_1B
-```
+**Memory Baseline Tracking:**
 
-**Monitoring:**
+When a model transitions to 'running' status, the backend captures its memory baseline:
+- `memoryBaselineByGpu: Record<number, number>` - Memory footprint per GPU in GB
+- Represents idle memory consumption before any inference requests
+- Used for accurate KVCache total calculation:
+  ```
+  KVCache Total = GPU Total - Model Baselines - Other Processes
+  ```
+
+**Memory Monitoring:**
 ```bash
 kvctl status  # Shows all segments and usage
+```
+
+**Memory Cleanup (Server Shutdown Only):**
+
+IPC segments are only deleted when the server shuts down:
+```bash
+kvctl delete kvcached_vllm_GPU0
+kvctl delete kvcached_vllm_GPU0_GPU1  # For tensor-parallel segments
 ```
 
 ### GPU Memory Allocation Strategy
@@ -486,7 +500,7 @@ Example (24GB GPU):
 - Model C (1B params): 4GB
 - Buffer: 4GB
 
-For detailed KVCached documentation, see [`kvcached/README.md`](./kvcached/README.md).
+For detailed kvcached documentation, see [`kvcached/README.md`](./kvcached/README.md).
 
 ## Security Model
 
@@ -511,7 +525,7 @@ For detailed KVCached documentation, see [`kvcached/README.md`](./kvcached/READM
 
 - **No credentials in logs**: Sanitize all log output
 - **Process isolation**: Each vLLM instance runs in separate process
-- **Resource limits**: Prevent memory exhaustion via KVCached limits
+- **Resource limits**: Prevent memory exhaustion via kvcached limits
 - **API versioning**: URL-based versioning (`/api/v1/`) for backward compatibility
 
 ## Performance Considerations
@@ -535,7 +549,7 @@ For detailed KVCached documentation, see [`kvcached/README.md`](./kvcached/READM
 
 #### vLLM Performance
 
-- **Prefix Caching:** Disabled (incompatible with KVCached)
+- **Prefix Caching:** Disabled (incompatible with kvcached)
 - **GPU Utilization:** Tuned per-model based on expected load
 - **Batch Size:** Dynamic batching handled by vLLM
 - **Attention Backend:** FlashAttention 2.0 (automatic)
@@ -583,4 +597,4 @@ This architecture follows the principles defined in [`.specify/memory/constituti
 - [Frontend Architecture](./architecture/frontend-architecture.md) - Detailed frontend component documentation
 - [API Guide](./api-guide.md) - API usage examples
 - [Deployment Guide](./deployment.md) - Container and OpenShift deployment
-- [KVCached Documentation](./kvcached/) - GPU memory sharing details
+- [kvcached Documentation](./kvcached/) - GPU memory sharing details

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -34,7 +34,7 @@ Core service managing vLLM subprocess lifecycle:
 - **Status transitions**: `starting` → `active` (success) or `failed` (error/timeout)
 - **Multi-instance support**: Multiple instances of same model via unique instance IDs
 - **Multi-GPU support**: GPU selection via `gpu_ids` and `tensor_parallel_size` parameters
-- **KVCached integration**: All single-GPU models share `kvcached_mem_info` IPC segment (disabled for tensor parallel)
+- **kvcached integration**: All single-GPU models share `kvcached_mem_info` IPC segment (disabled for tensor parallel)
 - **SIGKILL unload**: Uses SIGKILL (not SIGTERM) to bypass Python cleanup that would delete shared IPC
 - **EngineCore PID tracking**: Extracts GPU-using process PID from logs for accurate memory monitoring
 - **Conflict group detection**: Union-Find algorithm groups models sharing any GPU for sequential loading
@@ -117,7 +117,7 @@ Intelligent GPU selection for model loading:
 **Tensor Parallel Rules:**
 
 - `tensor_parallel_size > 1` requires that many contiguous GPUs
-- KVCached is automatically disabled for tensor parallel models
+- kvcached is automatically disabled for tensor parallel models
 - GPUs passed to vLLM via `CUDA_VISIBLE_DEVICES` environment variable
 
 ### BenchmarkRunner (`src/services/benchmark-runner.ts`)
@@ -218,7 +218,7 @@ DELETE /api/models/instances/:instance_id
 
 ### Why SIGKILL Instead of SIGTERM
 
-KVCached registers Python signal handlers in `MemInfoTracker` that delete the shared IPC segment (`kvcached_mem_info`) when receiving SIGTERM. Since all models share this single IPC segment, using SIGTERM to unload one model would break all other running models.
+kvcached registers Python signal handlers in `MemInfoTracker` that delete the shared IPC segment (`kvcached_mem_info`) when receiving SIGTERM. Since all models share this single IPC segment, using SIGTERM to unload one model would break all other running models.
 
 **Solution:** Use SIGKILL which bypasses signal handlers entirely. The shared IPC is only deleted during server shutdown when all models are gone.
 
@@ -233,10 +233,19 @@ SIGKILL doesn't propagate to children, so `killProcessImmediate()` uses `getDesc
 
 ### IPC Segment Lifecycle
 
-- **Created:** Automatically by first vLLM process with `ENABLE_KVCACHED=true`
-- **Shared:** All models use the same `kvcached_mem_info` segment
+Each GPU (or GPU-pair for tensor-parallel models) gets its own IPC segment:
+
+**Naming Convention:**
+- Single GPU: `kvcached_vllm_GPU{id}` (e.g., `kvcached_vllm_GPU0`)
+- Tensor-parallel: `kvcached_vllm_GPU{id1}_GPU{id2}` (e.g., `kvcached_vllm_GPU0_GPU1`)
+
+The segment name is set via `KVCACHED_IPC_NAME` environment variable, configured automatically by the backend based on the model's GPU assignment.
+
+**Lifecycle:**
+- **Created:** Automatically by first vLLM process with `ENABLE_KVCACHED=true` on that GPU
 - **Preserved:** Not deleted when individual models unload (SIGKILL bypasses cleanup)
 - **Deleted:** Only on server shutdown via `cleanup()` → `deleteSharedIpcSegment()`
+- **Multi-GPU cleanup:** Both single-GPU and multi-GPU segment patterns are cleaned up
 
 ## GPU Memory Tracking
 
@@ -263,6 +272,22 @@ vLLM Process Architecture:
 2. Store in `ModelInstance.engineCorePid`
 3. Use `engineCorePid` (falling back to `processId`) for nvidia-smi lookups
 4. Per-model memory breakdown in dashboard uses this PID for accurate reporting
+
+### Memory Baseline Tracking
+
+When a model transitions to 'running' status, the backend captures its memory baseline:
+
+- **`memoryBaselineByGpu: Record<number, number>`** - Memory footprint per GPU in GB
+- This represents the idle memory consumption before any inference requests
+- Captured from nvidia-smi using the EngineCore PID
+- For tensor-parallel models, baselines are captured on each GPU
+
+**Purpose:** The memory baseline is used for accurate KVCache total calculation:
+```
+KVCache Total = GPU Total - Model Baselines - Other Processes
+```
+
+This replaces the old approach of reading `total_size` from the IPC segment, which was set at initialization and never updated as models were added/removed.
 
 ## Logging Architecture
 
@@ -299,4 +324,4 @@ interface FastifyContextConfig {
 - [Architecture Overview](../architecture.md) - High-level system architecture
 - [Frontend Architecture](./frontend-architecture.md) - Frontend component specs
 - [API Guide](../api-guide.md) - API usage examples
-- [KVCached Documentation](../kvcached/) - GPU memory sharing details
+- [kvcached Documentation](../kvcached/) - GPU memory sharing details

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -29,7 +29,7 @@ This guide covers container building and deployment to OpenShift/Kubernetes.
 
 | Software                     | Version | Purpose                  |
 | ---------------------------- | ------- | ------------------------ |
-| **Docker**                   | 24.x+   | Container runtime        |
+| **Podman**                   | 4.x+    | Container runtime        |
 | **NVIDIA Container Toolkit** | 1.14.x+ | GPU access in containers |
 | **CUDA**                     | 12.x    | GPU compute              |
 | **OpenShift** (optional)     | 4.12+   | Production orchestration |
@@ -51,15 +51,14 @@ curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-contai
 sudo apt-get update
 sudo apt-get install -y nvidia-container-toolkit
 
-# Configure Docker to use NVIDIA runtime
-sudo nvidia-ctk runtime configure --runtime=docker
-sudo systemctl restart docker
+# Configure Podman to use NVIDIA runtime (via CDI)
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 ```
 
 **Verify GPU Access:**
 
 ```bash
-docker run --rm --gpus all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi
+podman run --rm --device nvidia.com/gpu=all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi
 ```
 
 ## Container Build
@@ -78,21 +77,21 @@ The unified container image includes:
 **From project root:**
 
 ```bash
-# Build the image
-docker build -t sardeenz:latest .
+# Build and tag using Makefile (recommended)
+make build VERSION=x.y.z
+make push VERSION=x.y.z
 
-# Tag for registry
-docker tag sardeenz:latest quay.io/your-org/sardeenz:latest
-
-# Push to registry
-docker push quay.io/your-org/sardeenz:latest
+# Or manually with podman:
+podman build -f docker/Containerfile -t quay.io/rh-aiservices-bu/sardeenz:x.y.z .
+podman push quay.io/rh-aiservices-bu/sardeenz:x.y.z
 ```
 
 **Build with custom vLLM version:**
 
 ```bash
-docker build \
+podman build \
   --build-arg VLLM_BASE_IMAGE=quay.io/vllm/vllm-cuda:0.12.0 \
+  -f docker/Containerfile \
   -t sardeenz:custom .
 ```
 
@@ -129,7 +128,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     npm install -g npm@latest
 
-# Install KVCached
+# Install kvcached
 RUN pip install kvcached
 
 # Copy built artifacts
@@ -156,9 +155,9 @@ CMD ["node", "backend/index.js"]
 
 ## Local Development
 
-### Run with Docker Compose
+### Run with Podman Compose
 
-**`docker-compose.yml`:**
+**`podman-compose.yml`:**
 
 ```yaml
 version: '3.8'
@@ -177,7 +176,7 @@ services:
       - AUTH_MODE=none # Disable auth for local dev
     volumes:
       - ./models:/opt/app-root/models # Mount local models directory for HF cache
-      - /tmp/kvcached:/tmp/kvcached # KVCached IPC directory
+      - /tmp/kvcached:/tmp/kvcached # kvcached IPC directory
     deploy:
       resources:
         reservations:
@@ -195,28 +194,28 @@ services:
 **Start the stack:**
 
 ```bash
-docker compose up -d
+podman-compose up -d
 
 # View logs
-docker compose logs -f
+podman-compose logs -f
 
 # Stop the stack
-docker compose down
+podman-compose down
 ```
 
 ### Run Standalone Container
 
 ```bash
-docker run -d \
+podman run -d \
   --name sardeenz \
-  --gpus all \
+  --device nvidia.com/gpu=all \
   -p 3000:3000 \
   -e ENABLE_KVCACHED=true \
   -e KVCACHED_AUTOPATCH=1 \
   -e HF_HOME=/opt/app-root/models \
   -v /path/to/models:/opt/app-root/models \
   -v /tmp/kvcached:/tmp/kvcached \
-  sardeenz:latest
+  quay.io/rh-aiservices-bu/sardeenz:latest
 ```
 
 ## OpenShift Deployment
@@ -616,8 +615,8 @@ For detailed permissions by role, see [API Guide: RBAC Roles](./api-guide.md#rba
 | `HF_HOME`              | Yes                 | -                  | HuggingFace cache directory for model downloads (e.g., `/opt/app-root/models`)                                                   |
 | `HF_TOKEN`             | No                  | -                  | HuggingFace token for accessing gated models (e.g., Llama, Mistral)                                                              |
 | `SARDEENZ_DB_PATH`     | No                  | `data/sardeenz.db` | SQLite database file path for persistent storage (e.g., `/opt/app-root/src/data/sardeenz.db`)                                    |
-| `ENABLE_KVCACHED`      | Yes                 | `true`             | Enable KVCached memory sharing                                                                                                   |
-| `KVCACHED_AUTOPATCH`   | No                  | `1`                | Auto-patch vLLM for KVCached                                                                                                     |
+| `ENABLE_KVCACHED`      | Yes                 | `true`             | Enable kvcached memory sharing                                                                                                   |
+| `KVCACHED_AUTOPATCH`   | No                  | `1`                | Auto-patch vLLM for kvcached                                                                                                     |
 | `LOG_LEVEL`            | No                  | `info`             | Logging level (`debug`, `info`, `warn`, `error`)                                                                                 |
 | `AUTH_MODE`            | No                  | `none`             | Authentication mode: `none` (disabled), `simple` (username/password), `oauth` (OAuth 2.0)                                        |
 | `ADMIN_USERNAME`       | No                  | `admin`            | Username for simple auth mode                                                                                                    |
@@ -786,7 +785,7 @@ oc describe node <gpu-node-name> | grep nvidia.com/gpu
 # Check available GPU memory
 oc exec -it <pod-name> -- nvidia-smi
 
-# Check KVCached status
+# Check kvcached status
 oc exec -it <pod-name> -- kvctl status
 ```
 
@@ -868,4 +867,4 @@ oc logs -f deployment/sardeenz | jq .
 
 - [Architecture](./architecture.md) - System architecture and design
 - [API Guide](./api-guide.md) - API usage examples
-- [KVCached Documentation](./kvcached/) - GPU memory sharing setup
+- [kvcached Documentation](./kvcached/) - GPU memory sharing setup

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,6 +1,6 @@
 # GPU Development Setup
 
-This guide covers setting up a local development environment with NVIDIA GPU support for running vLLM and KVCached.
+This guide covers setting up a local development environment with NVIDIA GPU support for running vLLM and kvcached.
 
 ## Prerequisites
 
@@ -44,8 +44,8 @@ npm run dev
 
 On first run, the script will:
 1. Create a Python virtual environment at `apps/backend/.venv`
-2. Install dependencies from `apps/backend/pyproject.toml` (vLLM, KVCached)
-3. Set up KVCached environment variables
+2. Install dependencies from `apps/backend/pyproject.toml` (vLLM, kvcached)
+3. Set up kvcached environment variables
 4. Start the backend and frontend development servers
 
 ## How It Works
@@ -54,12 +54,12 @@ On first run, the script will:
 
 The backend uses environment variables for configuration. A reference file is available at `apps/backend/.env.example`.
 
-**KVCached variables** (configured by start-dev script):
+**kvcached variables** (configured by start-dev script):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENABLE_KVCACHED` | `true` | Enables KVCached memory sharing |
-| `KVCACHED_AUTOPATCH` | `1` | Auto-patches vLLM for KVCached support |
+| `ENABLE_KVCACHED` | `true` | Enables kvcached memory sharing |
+| `KVCACHED_AUTOPATCH` | `1` | Auto-patches vLLM for kvcached support |
 | `CUDA_VISIBLE_DEVICES` | `0` | GPU device index |
 
 **HuggingFace authentication** (for gated models like Llama):
@@ -75,9 +75,9 @@ Get your token from [HuggingFace Settings](https://huggingface.co/settings/token
 Models are loaded dynamically via the API or Admin Dashboard - no models are pre-loaded at startup. When you load a model:
 
 1. Backend receives the load request
-2. vLLM process is spawned with KVCached environment
+2. vLLM process is spawned with kvcached environment
 3. Model is downloaded (if not cached) and loaded to GPU
-4. Multiple models can share GPU memory via KVCached
+4. Multiple models can share GPU memory via kvcached
 
 ## Recommended Models for 8GB VRAM
 
@@ -93,7 +93,7 @@ For development and testing on 8GB GPUs:
 ### Memory Tips
 
 - Use `--gpu-memory-utilization 0.3` for small models to leave room for others
-- With KVCached, you can load 2-3 small models on an 8GB GPU
+- With kvcached, you can load 2-3 small models on an 8GB GPU
 - Monitor VRAM with `nvidia-smi` or the Admin Dashboard
 
 ## Python Dependency Management
@@ -199,7 +199,7 @@ source .venv/bin/activate
 which vllm  # Should show path in .venv/bin/
 ```
 
-### KVCached IPC errors
+### kvcached IPC errors
 
 If you see IPC segment errors:
 ```bash
@@ -207,9 +207,9 @@ If you see IPC segment errors:
 ipcs -m | grep $(whoami) | awk '{print $2}' | xargs -I {} ipcrm -m {}
 ```
 
-## KVCached Tools
+## kvcached Tools
 
-KVCached provides CLI tools for monitoring:
+kvcached provides CLI tools for monitoring:
 
 ```bash
 # Activate the venv first
@@ -229,4 +229,4 @@ kvctl limit <segment-name> 4G
 
 - [Architecture Documentation](./architecture.md) - System design and vLLM integration
 - [API Guide](./api-guide.md) - Model loading API endpoints
-- [KVCached Documentation](./kvcached/) - Detailed KVCached configuration
+- [kvcached Documentation](./kvcached/) - Detailed kvcached configuration

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -22,7 +22,7 @@ npm run build -w packages/utils
 npm run dev
 ```
 
-On first run, the backend will automatically set up a Python virtual environment with vLLM and KVCached.
+On first run, the backend will automatically set up a Python virtual environment with vLLM and kvcached.
 
 **GPU Development:** See [GPU Setup Guide](../dev-setup.md) for detailed GPU configuration, model recommendations, and troubleshooting.
 
@@ -68,7 +68,7 @@ npm run dev -w apps/frontend
 |-----------|-------|-------------|
 | **Backend** | [apps/backend/CLAUDE.md](../../apps/backend/CLAUDE.md) | Backend architecture, API patterns, process management |
 | **Frontend** | [apps/frontend/CLAUDE.md](../../apps/frontend/CLAUDE.md) | React patterns, PatternFly 6 components, state management |
-| **GPU Setup** | [dev-setup.md](../dev-setup.md) | vLLM, KVCached, Python environment |
+| **GPU Setup** | [dev-setup.md](../dev-setup.md) | vLLM, kvcached, Python environment |
 | **PatternFly 6** | [pf6-guide/](./pf6-guide/README.md) | UI component guide and best practices |
 | **API Client** | [frontend-api-client.md](./frontend-api-client.md) | Frontend API integration |
 

--- a/docs/kvcached/README.md
+++ b/docs/kvcached/README.md
@@ -1,30 +1,30 @@
-# KVCached Documentation
+# kvcached Documentation
 
-This directory contains comprehensive documentation about KVCached and how it will be integrated with the sardeenz backend.
+This directory contains comprehensive documentation about kvcached and how it will be integrated with the sardeenz backend.
 
 ## Table of Contents
 
 - [Overview](#overview)
-- [What is KVCached?](#what-is-kvcached)
+- [What is kvcached?](#what-is-kvcached)
 - [Key Features](#key-features)
 - [Quick Start](#quick-start)
 - [Documentation Structure](#documentation-structure)
 
 ## Overview
 
-**KVCached** is a KV (Key-Value) cache library designed for LLM serving and training on shared GPUs. It introduces an OS-style virtual memory abstraction to LLM systems, enabling elastic and demand-driven KV cache allocation.
+**kvcached** is a KV (Key-Value) cache library designed for LLM serving and training on shared GPUs. It introduces an OS-style virtual memory abstraction to LLM systems, enabling elastic and demand-driven KV cache allocation.
 
 This documentation focuses exclusively on **vLLM integration**, as sardeenz will not use SGLang.
 
 ### For sardeenz Users
 
-**Important**: sardeenz uses **KVCached's memory sharing capabilities** but **NOT the KVCached Controller**. We directly manage vLLM instances to enable true dynamic model loading without downtime.
+**Important**: sardeenz uses **kvcached's memory sharing capabilities** but **NOT the kvcached Controller**. We directly manage vLLM instances to enable true dynamic model loading without downtime.
 
 👉 **Start here**: [sardeenz-integration.md](./sardeenz-integration.md)
 
-## What is KVCached?
+## What is kvcached?
 
-KVCached provides:
+kvcached provides:
 
 - **Virtual Memory Abstraction**: Decouples logical KV cache from physical GPU memory
 - **Elastic Memory Allocation**: Dynamically allocate and reclaim KV memory based on demand
@@ -39,7 +39,7 @@ KVCached provides:
 
 ## Key Features
 
-### Core KVCached Features (Used by sardeenz)
+### Core kvcached Features (Used by sardeenz)
 
 #### 1. GPU Memory Sharing
 - **Virtual Memory Abstraction**: Multiple vLLM instances share GPU memory efficiently
@@ -54,7 +54,7 @@ KVCached provides:
 
 ### Controller Features (NOT used by sardeenz)
 
-The KVCached Controller provides additional features that sardeenz does **not** use:
+The kvcached Controller provides additional features that sardeenz does **not** use:
 
 - ❌ **Controller & Router**: Unified API endpoint (we implement our own)
 - ❌ **Automatic Sleep Management**: Idle model detection (optional feature we may add later)
@@ -84,7 +84,7 @@ docker pull ghcr.io/ovg-project/kvcached-vllm:latest
 
 **sardeenz uses direct vLLM instance management** (not the Controller):
 
-1. **Enable KVCached** (set environment variables):
+1. **Enable kvcached** (set environment variables):
 ```bash
 export ENABLE_KVCACHED=true
 export KVCACHED_AUTOPATCH=1
@@ -106,8 +106,8 @@ vllm serve Qwen/Qwen3-0.6B \
 ```
 
 **Important**:
-- KVCached does NOT support prefix caching. Always use `--no-enable-prefix-caching`.
-- Each model runs independently but shares GPU memory automatically via KVCached.
+- kvcached does NOT support prefix caching. Always use `--no-enable-prefix-caching`.
+- Each model runs independently but shares GPU memory automatically via kvcached.
 
 3. **Monitor memory usage**:
 ```bash
@@ -140,7 +140,7 @@ This documentation is organized into the following sections:
    - Memory management strategies
    - Implementation roadmap
 
-### KVCached Reference Documentation
+### kvcached Reference Documentation
 
 2. **[architecture.md](./architecture.md)** - System architecture and components
    - Core components overview
@@ -174,13 +174,13 @@ This documentation is organized into the following sections:
 
 ### Architectural Decision
 
-**sardeenz will NOT use the KVCached Controller.** Instead, the backend will directly manage individual vLLM instances.
+**sardeenz will NOT use the kvcached Controller.** Instead, the backend will directly manage individual vLLM instances.
 
-### How We Use KVCached
+### How We Use kvcached
 
-The sardeenz backend integrates with KVCached through:
+The sardeenz backend integrates with kvcached through:
 
-1. **Environment Variables**: Enable KVCached for each vLLM instance
+1. **Environment Variables**: Enable kvcached for each vLLM instance
    ```python
    env["ENABLE_KVCACHED"] = "true"
    env["KVCACHED_AUTOPATCH"] = "1"
@@ -188,7 +188,7 @@ The sardeenz backend integrates with KVCached through:
 
 2. **Direct vLLM Process Management**: Launch and stop vLLM instances programmatically
    - Each model runs independently on its own port
-   - Models automatically share GPU memory via KVCached
+   - Models automatically share GPU memory via kvcached
 
 3. **Memory Monitoring**: Use kvctl/kvtop CLI tools
    - Track GPU memory usage across all models
@@ -203,7 +203,7 @@ The sardeenz backend integrates with KVCached through:
 
 ### Why This Approach?
 
-**The KVCached Controller requires a full restart to add/remove models**, which:
+**The kvcached Controller requires a full restart to add/remove models**, which:
 - ❌ Kills all running model instances
 - ❌ Causes downtime for all models
 - ❌ Requires reloading model weights from disk (slow)
@@ -234,7 +234,7 @@ See **[sardeenz-integration.md](./sardeenz-integration.md)** for:
 
 ## Limitations and Considerations
 
-- **No Prefix Caching Support**: Must disable prefix caching when using KVCached
+- **No Prefix Caching Support**: Must disable prefix caching when using kvcached
 - **vLLM Version**: Tested with v0.11.0; compatibility with other versions not guaranteed
 - **Memory Management**: Requires careful configuration for optimal performance
 - **GPU Requirements**: Designed for NVIDIA GPUs (future support for other hardware planned)

--- a/docs/kvcached/api-reference.md
+++ b/docs/kvcached/api-reference.md
@@ -1,6 +1,6 @@
-# KVCached API Reference
+# kvcached API Reference
 
-This document provides a complete reference for the KVCached Controller HTTP API endpoints.
+This document provides a complete reference for the kvcached Controller HTTP API endpoints.
 
 ## Table of Contents
 
@@ -14,7 +14,7 @@ This document provides a complete reference for the KVCached Controller HTTP API
 
 ## Base URL
 
-By default, the KVCached Controller listens on:
+By default, the kvcached Controller listens on:
 
 ```
 http://localhost:8080
@@ -670,10 +670,10 @@ print(response.json())
 ```python
 from openai import OpenAI
 
-# Point OpenAI client to KVCached Controller
+# Point OpenAI client to kvcached Controller
 client = OpenAI(
     base_url="http://localhost:8080/v1",
-    api_key="not-needed"  # KVCached doesn't require auth by default
+    api_key="not-needed"  # kvcached doesn't require auth by default
 )
 
 # Use like normal OpenAI API
@@ -742,7 +742,7 @@ curl -X POST http://localhost:8080/action/wakeup/$MODEL -H "Content-Type: applic
 
 ## Rate Limiting and Quotas
 
-KVCached Controller does not implement rate limiting by default. For production use, consider:
+kvcached Controller does not implement rate limiting by default. For production use, consider:
 
 - Adding a reverse proxy (nginx, Caddy) with rate limiting
 - Implementing application-level quotas
@@ -750,7 +750,7 @@ KVCached Controller does not implement rate limiting by default. For production 
 
 ## Authentication and Security
 
-By default, KVCached Controller does not require authentication. For production deployments:
+By default, kvcached Controller does not require authentication. For production deployments:
 
 - **Recommended**: Deploy behind a reverse proxy with authentication
 - **Network Security**: Use firewall rules to restrict access

--- a/docs/kvcached/architecture.md
+++ b/docs/kvcached/architecture.md
@@ -1,6 +1,6 @@
-# KVCached Architecture
+# kvcached Architecture
 
-This document describes the architecture of KVCached and how it integrates with vLLM for the sardeenz project.
+This document describes the architecture of kvcached and how it integrates with vLLM for the sardeenz project.
 
 ## Table of Contents
 
@@ -12,7 +12,7 @@ This document describes the architecture of KVCached and how it integrates with 
 
 ## System Overview
 
-KVCached implements an OS-style virtual memory abstraction for managing KV (Key-Value) caches in LLM serving environments. The system enables multiple vLLM instances to share GPU resources efficiently through dynamic memory allocation and intelligent model lifecycle management.
+kvcached implements an OS-style virtual memory abstraction for managing KV (Key-Value) caches in LLM serving environments. The system enables multiple vLLM instances to share GPU resources efficiently through dynamic memory allocation and intelligent model lifecycle management.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -44,7 +44,7 @@ KVCached implements an OS-style virtual memory abstraction for managing KV (Key-
        └────────────────┼────────────────┘
                         ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              KVCached Memory Management Layer                │
+│              kvcached Memory Management Layer                │
 │  ┌────────────────┐  ┌────────────────┐  ┌───────────────┐ │
 │  │ KV Cache       │  │ Page           │  │ Memory Info   │ │
 │  │ Manager        │  │ Allocator      │  │ Tracker       │ │
@@ -239,9 +239,9 @@ The **Memory Info Tracker** monitors GPU memory usage in real-time.
 
 ## vLLM Integration
 
-### How KVCached Integrates with vLLM
+### How kvcached Integrates with vLLM
 
-KVCached integrates with vLLM through **autopatching** - automatic modification of vLLM's memory management behavior at runtime.
+kvcached integrates with vLLM through **autopatching** - automatic modification of vLLM's memory management behavior at runtime.
 
 **Integration Method**:
 1. Set environment variables:
@@ -255,22 +255,22 @@ KVCached integrates with vLLM through **autopatching** - automatic modification 
    vllm serve meta-llama/Llama-3.2-1B --no-enable-prefix-caching
    ```
 
-3. KVCached automatically patches vLLM's KV cache allocation
+3. kvcached automatically patches vLLM's KV cache allocation
 
 **Autopatch Mechanism** (`kvcached/autopatch.py`):
 - Intercepts vLLM's memory allocation calls
-- Redirects to KVCached's virtual memory system
+- Redirects to kvcached's virtual memory system
 - Maintains compatibility with vLLM's API
 - Transparent to vLLM's internal logic
 
 **Key Integration Points**:
-- **Memory Allocation**: vLLM requests → KVCached Page Allocator
-- **KV Cache Storage**: vLLM cache → KVCached IPC segments
-- **Memory Release**: vLLM free → KVCached page deallocation
+- **Memory Allocation**: vLLM requests → kvcached Page Allocator
+- **KV Cache Storage**: vLLM cache → kvcached IPC segments
+- **Memory Release**: vLLM free → kvcached page deallocation
 
 ### vLLM-Specific Limitations
 
-- **No Prefix Caching**: KVCached does not support vLLM's prefix caching feature
+- **No Prefix Caching**: kvcached does not support vLLM's prefix caching feature
   - Must use `--no-enable-prefix-caching` flag
   - Incompatibility with `--enable-prefix-caching`
 
@@ -308,7 +308,7 @@ KVCached integrates with vLLM through **autopatching** - automatic modification 
    ```
 
 6. **vLLM** processes request:
-   - Allocates KV cache via KVCached
+   - Allocates KV cache via kvcached
    - Generates completion
    - Returns response
 
@@ -354,7 +354,7 @@ KVCached integrates with vLLM through **autopatching** - automatic modification 
 
 4. Model sleep operation:
    - Notifies vLLM to release KV cache
-   - KVCached reclaims GPU memory
+   - kvcached reclaims GPU memory
    - Model marked as sleeping
 
 ## Memory Management
@@ -369,13 +369,13 @@ KVCached integrates with vLLM through **autopatching** - automatic modification 
                   │
                   ▼
 ┌─────────────────────────────────────────────┐
-│      Virtual Memory Layer (KVCached)        │
+│      Virtual Memory Layer (kvcached)        │
 │  Logical KV cache addresses (per model)     │
 └─────────────────┬───────────────────────────┘
                   │
                   ▼
 ┌─────────────────────────────────────────────┐
-│         Page Allocator (KVCached)           │
+│         Page Allocator (kvcached)           │
 │    Physical page allocation & tracking      │
 └─────────────────┬───────────────────────────┘
                   │
@@ -555,7 +555,7 @@ After Model A Goes Idle (Auto-Sleep):
 
 ## Performance Considerations
 
-### Benefits of KVCached Architecture
+### Benefits of kvcached Architecture
 
 1. **Improved TTFT (Time To First Token)**:
    - 2-28x reduction in TTFT
@@ -593,7 +593,7 @@ After Model A Goes Idle (Auto-Sleep):
 
 ## Summary
 
-KVCached provides a sophisticated architecture for managing multiple vLLM instances on shared GPU resources. The key innovation is the **virtual memory abstraction** that decouples logical KV cache from physical GPU memory, combined with **intelligent lifecycle management** through the Sleep Manager.
+kvcached provides a sophisticated architecture for managing multiple vLLM instances on shared GPU resources. The key innovation is the **virtual memory abstraction** that decouples logical KV cache from physical GPU memory, combined with **intelligent lifecycle management** through the Sleep Manager.
 
 For sardeenz, the most important integration points are:
 - **Controller API** for model management

--- a/docs/kvcached/cli-tools.md
+++ b/docs/kvcached/cli-tools.md
@@ -1,6 +1,6 @@
-# KVCached CLI Tools Reference
+# kvcached CLI Tools Reference
 
-This document provides a complete reference for KVCached's command-line tools for memory management and monitoring.
+This document provides a complete reference for kvcached's command-line tools for memory management and monitoring.
 
 ## Table of Contents
 
@@ -12,7 +12,7 @@ This document provides a complete reference for KVCached's command-line tools fo
 
 ## Overview
 
-KVCached provides two primary CLI tools for managing GPU memory:
+kvcached provides two primary CLI tools for managing GPU memory:
 
 1. **kvctl**: Interactive CLI for memory management and control
 2. **kvtop**: Real-time visual monitoring of memory usage (like `htop` for KV cache)
@@ -25,7 +25,7 @@ Both tools operate on **IPC (Inter-Process Communication) segments**, which are 
 
 ### Installation
 
-kvctl is included with the KVCached package:
+kvctl is included with the kvcached package:
 
 ```bash
 pip install kvcached --no-build-isolation
@@ -164,7 +164,7 @@ Memory limit for VLLM_MODEL_1 set to 30% (7.2 GB of 24 GB total)
 
 **Use Cases**:
 - Ensure fair sharing among models
-- Reserve GPU memory for non-KVCached workloads
+- Reserve GPU memory for non-kvcached workloads
 - Dynamic allocation based on available GPU memory
 
 #### watch
@@ -321,7 +321,7 @@ kvctl> exit
 
 ### Installation
 
-Included with KVCached:
+Included with kvcached:
 
 ```bash
 pip install kvcached --no-build-isolation
@@ -367,7 +367,7 @@ kvtop --refresh 0.5
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                         KVCached Memory Monitor                  │
+│                         kvcached Memory Monitor                  │
 │                      Refresh: 1.0s | Press q to quit             │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                  │
@@ -535,7 +535,7 @@ kvtop
 
 ### Programmatic Access (Python)
 
-While kvctl and kvtop are CLI tools, you can programmatically interact with IPC segments through KVCached's Python API:
+While kvctl and kvtop are CLI tools, you can programmatically interact with IPC segments through kvcached's Python API:
 
 ```python
 from kvcached import MemoryManager
@@ -640,7 +640,7 @@ if __name__ == '__main__':
 Automate memory management in sardeenz backend:
 
 ```python
-class KVCachedMemoryManager:
+class kvcachedMemoryManager:
     """Manage KV cache memory for models."""
 
     def __init__(self, total_gpu_memory_gb=24):
@@ -678,7 +678,7 @@ class KVCachedMemoryManager:
         del self.models[model_name]
 
 # Usage
-manager = KVCachedMemoryManager(total_gpu_memory_gb=24)
+manager = kvcachedMemoryManager(total_gpu_memory_gb=24)
 
 # Register models
 manager.register_model("llama-3.2-1b", "VLLM_LLAMA", memory_percent=40)
@@ -711,7 +711,7 @@ manager.cleanup_model("llama-3.2-1b")
 **Solutions**:
 - Verify `ENABLE_KVCACHED=true` environment variable is set
 - Verify `KVCACHED_AUTOPATCH=1` is set
-- Check model logs for KVCached initialization errors
+- Check model logs for kvcached initialization errors
 - Ensure vLLM v0.11.0 is being used
 
 ### Memory Limit Not Enforced

--- a/docs/kvcached/configuration.md
+++ b/docs/kvcached/configuration.md
@@ -1,6 +1,6 @@
-# KVCached Configuration Guide
+# kvcached Configuration Guide
 
-This document describes how to configure KVCached for managing multiple vLLM models.
+This document describes how to configure kvcached for managing multiple vLLM models.
 
 ## Table of Contents
 
@@ -10,15 +10,15 @@ This document describes how to configure KVCached for managing multiple vLLM mod
 - [Model Instance Configuration](#model-instance-configuration)
 - [Router Configuration](#router-configuration)
 - [Sleep Manager Configuration](#sleep-manager-configuration)
-- [KVCached Global Settings](#kvcached-global-settings)
+- [kvcached Global Settings](#kvcached-global-settings)
 - [Complete Configuration Examples](#complete-configuration-examples)
 - [Configuration for sardeenz](#configuration-for-sardeenz)
 
 ## Configuration Overview
 
-KVCached configuration consists of two parts:
+kvcached configuration consists of two parts:
 
-1. **Environment Variables**: Enable KVCached and set runtime options
+1. **Environment Variables**: Enable kvcached and set runtime options
 2. **YAML Configuration File**: Define models, router, and sleep management settings
 
 ### Configuration Hierarchy
@@ -37,10 +37,10 @@ YAML Configuration File
 
 ### Required Variables
 
-These variables must be set for KVCached to work with vLLM:
+These variables must be set for kvcached to work with vLLM:
 
 ```bash
-# Enable KVCached
+# Enable kvcached
 export ENABLE_KVCACHED=true
 
 # Enable automatic patching of vLLM
@@ -61,9 +61,29 @@ export KVCACHED_PREALLOCATE_PAGES=true
 # Log level (DEBUG, INFO, WARNING, ERROR)
 export KVCACHED_LOG_LEVEL=INFO
 
-# IPC segment name prefix
+# IPC segment name prefix (legacy)
 export KVCACHED_IPC_PREFIX="VLLM"
 ```
+
+### KVCACHED_IPC_NAME
+
+Per-GPU IPC segment name set automatically by sardeenz backend based on GPU assignment:
+
+```bash
+# Single GPU on GPU 0
+export KVCACHED_IPC_NAME="kvcached_vllm_GPU0"
+
+# Single GPU on GPU 1
+export KVCACHED_IPC_NAME="kvcached_vllm_GPU1"
+
+# Tensor-parallel on GPUs 0 and 1
+export KVCACHED_IPC_NAME="kvcached_vllm_GPU0_GPU1"
+
+# Tensor-parallel on GPUs 0-3
+export KVCACHED_IPC_NAME="kvcached_vllm_GPU0_GPU1_GPU2_GPU3"
+```
+
+This replaces the old global `kvcached_mem_info` segment with per-GPU segments for accurate multi-model memory tracking across GPUs. The sardeenz backend automatically sets this environment variable based on the model's `gpuIds` configuration.
 
 ### Setting Environment Variables
 
@@ -98,12 +118,12 @@ export $(cat .env | xargs)
 
 ## YAML Configuration File
 
-The YAML configuration file defines the entire KVCached Controller setup, including models, router, and sleep management.
+The YAML configuration file defines the entire kvcached Controller setup, including models, router, and sleep management.
 
 ### Basic Structure
 
 ```yaml
-# Global KVCached settings
+# Global kvcached settings
 kvcached:
   gpu_memory_utilization: 0.9
   preallocate_pages: true
@@ -132,7 +152,7 @@ instances:
 
 ### Configuration Sections
 
-1. **kvcached**: Global KVCached runtime settings
+1. **kvcached**: Global kvcached runtime settings
 2. **router**: HTTP API server configuration
 3. **sleep_manager**: Model lifecycle management
 4. **instances**: Individual model configurations (array)
@@ -213,7 +233,7 @@ instances:
     # vLLM engine arguments
     engine_args:
       disable_log_requests: true
-      enable_prefix_caching: false     # Must be false for KVCached
+      enable_prefix_caching: false     # Must be false for kvcached
       tensor_parallel_size: 1
       gpu_memory_utilization: 0.9
       max_model_len: 4096
@@ -224,8 +244,8 @@ instances:
 **Field**:
 - `engine_args` (object, optional): Arguments passed to `vllm serve`
 
-**Important vLLM Arguments for KVCached**:
-- `enable_prefix_caching`: **Must be `false`** (KVCached incompatible)
+**Important vLLM Arguments for kvcached**:
+- `enable_prefix_caching`: **Must be `false`** (kvcached incompatible)
 - `disable_log_requests`: Recommended for cleaner logs
 - `gpu_memory_utilization`: Memory fraction for model weights (0.0-1.0)
 - `tensor_parallel_size`: Number of GPUs for tensor parallelism
@@ -384,9 +404,9 @@ sleep_manager:
   enabled: false                     # No sleep management
 ```
 
-## KVCached Global Settings
+## kvcached Global Settings
 
-Global KVCached runtime settings:
+Global kvcached runtime settings:
 
 ```yaml
 kvcached:
@@ -408,7 +428,7 @@ kvcached:
 
 ### GPU Memory Utilization
 
-Controls how much GPU memory KVCached can use for KV cache:
+Controls how much GPU memory kvcached can use for KV cache:
 
 ```yaml
 kvcached:
@@ -451,7 +471,7 @@ kvcached:
 ```
 
 **Use Cases**:
-- `DEBUG`: Troubleshooting KVCached issues
+- `DEBUG`: Troubleshooting kvcached issues
 - `INFO`: Normal operation (default)
 - `WARNING`: Production with minimal logging
 - `ERROR`: Only critical issues
@@ -621,7 +641,7 @@ For sardeenz, the backend should dynamically generate YAML configurations based 
 ```python
 # Backend generates config based on user's model selections
 def generate_kvcached_config(models, gpu_memory_gb=24):
-    """Generate KVCached YAML config for requested models."""
+    """Generate kvcached YAML config for requested models."""
 
     # Calculate memory allocation per model
     num_models = len(models)

--- a/docs/kvcached/model-lifecycle.md
+++ b/docs/kvcached/model-lifecycle.md
@@ -1,6 +1,6 @@
-# KVCached Model Lifecycle Management
+# kvcached Model Lifecycle Management
 
-This document describes how to manage the lifecycle of vLLM models using KVCached, including loading, unloading, sleeping, waking, and monitoring model usage.
+This document describes how to manage the lifecycle of vLLM models using kvcached, including loading, unloading, sleeping, waking, and monitoring model usage.
 
 ## Table of Contents
 
@@ -14,7 +14,7 @@ This document describes how to manage the lifecycle of vLLM models using KVCache
 
 ## Model Lifecycle Overview
 
-KVCached models go through several states during their lifecycle:
+kvcached models go through several states during their lifecycle:
 
 ```
 ┌─────────────┐
@@ -50,7 +50,7 @@ KVCached models go through several states during their lifecycle:
 
 ## Loading Models
 
-There are three methods to load models with KVCached:
+There are three methods to load models with kvcached:
 
 1. **Controller Launch** (Recommended for multi-model setups)
 2. **Manual vLLM Launch** (For single models or custom setups)
@@ -58,7 +58,7 @@ There are three methods to load models with KVCached:
 
 ### Method 1: Controller Launch
 
-Use the KVCached Controller to launch and manage multiple models from a YAML configuration.
+Use the kvcached Controller to launch and manage multiple models from a YAML configuration.
 
 **Configuration File** (`config.yaml`):
 ```yaml
@@ -123,7 +123,7 @@ curl http://localhost:8080/health
 
 ### Method 2: Manual vLLM Launch
 
-Launch vLLM directly with KVCached enabled.
+Launch vLLM directly with kvcached enabled.
 
 **Command**:
 ```bash
@@ -145,7 +145,7 @@ vllm serve meta-llama/Llama-3.2-1B \
 # Check vLLM is responding
 curl http://localhost:12346/v1/models
 
-# Check KVCached IPC segment
+# Check kvcached IPC segment
 kvctl list
 ```
 
@@ -167,7 +167,7 @@ import time
 import requests
 
 def launch_vllm_model(model_path, port, max_tokens=4096):
-    """Launch a vLLM model with KVCached enabled."""
+    """Launch a vLLM model with kvcached enabled."""
 
     # Set environment
     env = os.environ.copy()
@@ -217,7 +217,7 @@ import yaml
 import subprocess
 
 def launch_with_controller(models):
-    """Launch multiple models using KVCached controller."""
+    """Launch multiple models using kvcached controller."""
 
     # Generate config
     config = {
@@ -280,11 +280,11 @@ process = launch_with_controller(models)
 
 ## Unloading Models
 
-Models can be unloaded by stopping their processes. **Important:** When using KVCached with shared memory, you must use SIGKILL (not SIGTERM) to avoid deleting the shared IPC segment.
+Models can be unloaded by stopping their processes. **Important:** When using kvcached with shared memory, you must use SIGKILL (not SIGTERM) to avoid deleting the shared IPC segment.
 
 ### Understanding IPC Lifecycle
 
-KVCached uses a shared IPC segment (`kvcached_mem_info`) for all models. When a vLLM process receives SIGTERM, Python's signal handlers run `MemInfoTracker.cleanup()` which deletes this shared segment, breaking all other running models.
+kvcached uses a shared IPC segment (`kvcached_mem_info`) for all models. When a vLLM process receives SIGTERM, Python's signal handlers run `MemInfoTracker.cleanup()` which deletes this shared segment, breaking all other running models.
 
 **Solution:** Use SIGKILL to bypass signal handlers. The shared IPC segment is only deleted on server shutdown when all models are gone.
 
@@ -439,7 +439,7 @@ def shutdown_all(self):
 
 ## Model Sleep and Wake
 
-KVCached's key feature is the ability to put models to sleep and wake them on demand.
+kvcached's key feature is the ability to put models to sleep and wake them on demand.
 
 ### Automatic Sleep
 
@@ -635,7 +635,7 @@ curl http://localhost:8080/sleep/candidates
 
 ## Usage Reporting and Monitoring
 
-KVCached provides comprehensive usage reporting through traffic monitoring and memory tracking.
+kvcached provides comprehensive usage reporting through traffic monitoring and memory tracking.
 
 ### Traffic Statistics
 
@@ -757,8 +757,8 @@ curl http://localhost:8080/health/$MODEL
 ```python
 import requests
 
-class KVCachedMonitor:
-    """Monitor KVCached models."""
+class kvcachedMonitor:
+    """Monitor kvcached models."""
 
     def __init__(self, base_url="http://localhost:8080"):
         self.base_url = base_url
@@ -800,7 +800,7 @@ class KVCachedMonitor:
         return response.json()
 
 # Usage
-monitor = KVCachedMonitor()
+monitor = kvcachedMonitor()
 
 # Get overall stats
 stats = monitor.get_traffic_stats()
@@ -1039,14 +1039,14 @@ The sardeenz backend manages the entire model lifecycle:
 
 ```python
 class ModelStackerBackend:
-    """Backend for sardeenz with KVCached integration."""
+    """Backend for sardeenz with kvcached integration."""
 
     def __init__(self):
         self.controller_process = None
         self.active_models = []
 
     def deploy_models(self, model_configs):
-        """Deploy multiple models using KVCached controller."""
+        """Deploy multiple models using kvcached controller."""
 
         # Generate YAML config
         config = self._generate_config(model_configs)
@@ -1068,7 +1068,7 @@ class ModelStackerBackend:
         self.active_models = [m["name"] for m in model_configs]
 
     def _generate_config(self, model_configs):
-        """Generate KVCached YAML config."""
+        """Generate kvcached YAML config."""
         return {
             "kvcached": {
                 "gpu_memory_utilization": 0.9,
@@ -1160,13 +1160,13 @@ KVCACHED_URL = "http://localhost:8080"
 
 @app.route("/v1/completions", methods=["POST"])
 def completions():
-    """Proxy completion requests to KVCached."""
+    """Proxy completion requests to kvcached."""
 
     # Log request for tracking
     data = request.json
     model_name = data.get("model")
 
-    # Forward to KVCached
+    # Forward to kvcached
     response = requests.post(
         f"{KVCACHED_URL}/v1/completions",
         json=data

--- a/docs/kvcached/sardeenz-integration.md
+++ b/docs/kvcached/sardeenz-integration.md
@@ -1,11 +1,11 @@
-# KVCached Integration Guide for sardeenz
+# kvcached Integration Guide for sardeenz
 
-This document describes how the sardeenz project will integrate with KVCached for dynamic multi-model management on shared GPUs.
+This document describes how the sardeenz project will integrate with kvcached for dynamic multi-model management on shared GPUs.
 
 ## Table of Contents
 
 - [Executive Summary](#executive-summary)
-- [Why Not Use the KVCached Controller](#why-not-use-the-kvcached-controller)
+- [Why Not Use the kvcached Controller](#why-not-use-the-kvcached-controller)
 - [Recommended Architecture](#recommended-architecture)
 - [Implementation Details](#implementation-details)
 - [Backend API Design](#backend-api-design)
@@ -16,7 +16,7 @@ This document describes how the sardeenz project will integrate with KVCached fo
 
 ## Executive Summary
 
-**Decision:** sardeenz will **NOT** use the KVCached Controller for model management. Instead, the backend will directly manage individual vLLM instances with KVCached enabled.
+**Decision:** sardeenz will **NOT** use the kvcached Controller for model management. Instead, the backend will directly manage individual vLLM instances with kvcached enabled.
 
 **Why:**
 - The Controller requires a full restart to add/remove models
@@ -25,22 +25,22 @@ This document describes how the sardeenz project will integrate with KVCached fo
 
 **How:**
 - Backend launches vLLM instances directly with `ENABLE_KVCACHED=true`
-- Each model runs independently but shares GPU memory via KVCached
+- Each model runs independently but shares GPU memory via kvcached
 - Backend implements its own routing, monitoring, and lifecycle management
-- Use KVCached CLI tools (`kvctl`, `kvtop`) for memory monitoring
+- Use kvcached CLI tools (`kvctl`, `kvtop`) for memory monitoring
 
 **Benefits:**
 - ✅ Add models without affecting running instances
 - ✅ Remove models individually with no downtime
 - ✅ Full control over model lifecycle
-- ✅ GPU memory sharing via KVCached still works automatically
+- ✅ GPU memory sharing via kvcached still works automatically
 - ✅ Simpler architecture (no Controller dependency)
 
-## Why Not Use the KVCached Controller
+## Why Not Use the kvcached Controller
 
 ### The Controller's Limitations
 
-The KVCached Controller is designed for **static, long-running deployments** where the model lineup is known in advance and rarely changes.
+The kvcached Controller is designed for **static, long-running deployments** where the model lineup is known in advance and rarely changes.
 
 #### Problem 1: No Dynamic Model Addition
 
@@ -171,7 +171,7 @@ For completeness, here's what the Controller provides that we're giving up:
 │         │                 │                 │           │
 │         └─────────────────┼─────────────────┘           │
 │                           ▼                             │
-│              KVCached Memory Sharing Layer              │
+│              kvcached Memory Sharing Layer              │
 │                  (Automatic, Transparent)               │
 └─────────────────────────────────────────────────────────┘
                            │
@@ -190,13 +190,13 @@ For completeness, here's what the Controller provides that we're giving up:
 - Health monitoring
 
 **Does NOT use:**
-- KVCached Controller
+- kvcached Controller
 - tmux sessions (Controller feature)
 - YAML configuration for model list
 
 **Uses:**
 - Direct subprocess management
-- KVCached environment variables
+- kvcached environment variables
 - Individual model processes
 
 #### 2. Request Router
@@ -221,22 +221,22 @@ For completeness, here's what the Controller provides that we're giving up:
 - `kvctl list --json` for programmatic access
 - `kvtop` for debugging/development
 
-### How KVCached Fits In
+### How kvcached Fits In
 
-**KVCached's role:**
+**kvcached's role:**
 - Enable GPU memory sharing between vLLM instances
 - Manage KV cache allocation dynamically
 - Allow multiple models to coexist on same GPU
 
 **What we use:**
-- ✅ KVCached's memory management layer (core feature)
-- ✅ KVCached CLI tools for monitoring
-- ✅ Environment variables for enabling KVCached
-- ❌ KVCached Controller (too inflexible)
+- ✅ kvcached's memory management layer (core feature)
+- ✅ kvcached CLI tools for monitoring
+- ✅ Environment variables for enabling kvcached
+- ❌ kvcached Controller (too inflexible)
 
 **How it works:**
 1. Backend sets `ENABLE_KVCACHED=true` for each vLLM launch
-2. Each vLLM instance automatically uses KVCached for memory
+2. Each vLLM instance automatically uses kvcached for memory
 3. GPU memory is shared transparently via IPC segments
 4. Backend uses `kvctl` to monitor and set limits
 
@@ -271,7 +271,7 @@ For completeness, here's what the Controller provides that we're giving up:
    process = subprocess.Popen([
        "vllm", "serve", "meta-llama/Llama-3.2-1B",
        "--disable-log-requests",
-       "--no-enable-prefix-caching",  # Required for KVCached
+       "--no-enable-prefix-caching",  # Required for kvcached
        "--port=12346",
        "--gpu-memory-utilization=0.9",
        "--max-model-len=4096"
@@ -341,10 +341,10 @@ For completeness, here's what the Controller provides that we're giving up:
    process.wait()
    ```
 
-   > **Important:** We use SIGKILL instead of SIGTERM because KVCached registers
-   > Python signal handlers that delete the shared IPC segment (`kvcached_mem_info`)
-   > on SIGTERM. Using SIGKILL bypasses these handlers, allowing other models to
-   > continue using the shared memory.
+   > **Important:** We use SIGKILL instead of SIGTERM because kvcached registers
+   > Python signal handlers that delete the IPC segment on SIGTERM. Using SIGKILL
+   > bypasses these handlers, allowing other models on the same GPU to continue
+   > using the shared memory.
    >
    > **Note:** SIGKILL doesn't propagate to child processes. vLLM spawns an EngineCore
    > process that allocates GPU VRAM, so we must explicitly kill all descendants
@@ -353,8 +353,8 @@ For completeness, here's what the Controller provides that we're giving up:
 3. **Do NOT delete IPC segment**
    ```python
    # DO NOT call kvctl delete here!
-   # All models share the same IPC segment (kvcached_mem_info)
-   # Deleting it would break other running models
+   # Models on the same GPU share the IPC segment (e.g., kvcached_vllm_GPU0)
+   # Deleting it would break other running models on that GPU
    ```
 
 4. **Backend removes from registry**
@@ -373,7 +373,20 @@ For completeness, here's what the Controller provides that we're giving up:
 
 **IPC Cleanup (Server Shutdown Only):**
 
-The shared IPC segment is only deleted when the server shuts down and all models are unloaded:
+The IPC segments are only deleted when the server shuts down and all models are unloaded.
+
+**IPC Segment Naming:**
+
+Each GPU (or GPU-pair for tensor-parallel models) gets its own IPC segment:
+
+| GPU Configuration | IPC Segment Name |
+|-------------------|------------------|
+| Single GPU (GPU 0) | `kvcached_vllm_GPU0` |
+| Single GPU (GPU 1) | `kvcached_vllm_GPU1` |
+| Tensor-parallel (GPU 0+1) | `kvcached_vllm_GPU0_GPU1` |
+| Tensor-parallel (GPU 0-3) | `kvcached_vllm_GPU0_GPU1_GPU2_GPU3` |
+
+This is configured automatically via the `KVCACHED_IPC_NAME` environment variable set by the backend based on the model's GPU assignment.
 
 ```python
 def shutdown_all(self):
@@ -382,8 +395,12 @@ def shutdown_all(self):
     for model_path in list(self.running_models.keys()):
         self.unload_model(model_path)
 
-    # Now delete the shared IPC segment
-    subprocess.run(["kvctl", "delete", "kvcached_mem_info"])
+    # Delete all kvcached IPC segments (single-GPU and multi-GPU patterns)
+    for i in range(8):  # Try single-GPU segments
+        subprocess.run(["kvctl", "delete", f"kvcached_vllm_GPU{i}"])
+    # Try common multi-GPU patterns
+    subprocess.run(["kvctl", "delete", "kvcached_vllm_GPU0_GPU1"])
+    subprocess.run(["kvctl", "delete", "kvcached_vllm_GPU0_GPU1_GPU2_GPU3"])
 ```
 
 ### Request Routing
@@ -459,7 +476,7 @@ from datetime import datetime
 import requests
 
 class ModelManager:
-    """Manages vLLM model instances with KVCached."""
+    """Manages vLLM model instances with kvcached."""
 
     def __init__(self, base_port: int = 12346):
         self.running_models: Dict[str, dict] = {}
@@ -472,7 +489,7 @@ class ModelManager:
         max_tokens: int = 4096,
         gpu_memory_utilization: float = 0.9
     ) -> dict:
-        """Launch a vLLM model with KVCached enabled."""
+        """Launch a vLLM model with kvcached enabled."""
 
         # Check if already running
         if model_path in self.running_models:
@@ -662,15 +679,22 @@ class ModelManager:
         for model_path in models:
             self.unload_model(model_path)
 
-        # Delete the shared KVCached IPC segment now that all models are gone
-        try:
-            subprocess.run(
-                ["kvctl", "delete", "kvcached_mem_info"],
-                capture_output=True,
-                timeout=5
-            )
-        except:
-            pass  # Non-critical if segment doesn't exist
+        # Delete all kvcached IPC segments (per-GPU and multi-GPU patterns)
+        for i in range(8):  # Try single-GPU segments
+            try:
+                subprocess.run(
+                    ["kvctl", "delete", f"kvcached_vllm_GPU{i}"],
+                    capture_output=True,
+                    timeout=5
+                )
+            except:
+                pass  # Non-critical if segment doesn't exist
+        # Try common multi-GPU patterns for tensor-parallel models
+        for segment in ["kvcached_vllm_GPU0_GPU1", "kvcached_vllm_GPU0_GPU1_GPU2_GPU3"]:
+            try:
+                subprocess.run(["kvctl", "delete", segment], capture_output=True, timeout=5)
+            except:
+                pass
 
 # Usage
 manager = ModelManager()
@@ -785,6 +809,23 @@ Response:
 ```
 
 ## Memory Management
+
+### Memory Baseline Tracking
+
+When a model transitions to 'running' status, the backend captures its memory baseline:
+
+- **`memoryBaselineByGpu: Record<number, number>`** - Memory footprint per GPU in GB
+- This represents the idle memory consumption before any inference requests
+- Captured from nvidia-smi using the EngineCore PID
+- For tensor-parallel models, baselines are captured on each GPU
+
+**Purpose:** The memory baseline is used for accurate KVCache total calculation:
+
+```
+KVCache Total = GPU Total - Model Baselines - Other Processes
+```
+
+This provides accurate KVCache metrics per GPU, as opposed to reading a stale `total_size` from the IPC segment that was set at initialization and never updated as models were added/removed.
 
 ### Setting Memory Limits
 
@@ -1087,7 +1128,7 @@ async def completions(request: Request):
 - Fewer moving parts
 - Easier debugging
 
-✅ **Same KVCached benefits**
+✅ **Same kvcached benefits**
 - GPU memory sharing still works
 - Multiple models coexist
 - Memory management via kvctl
@@ -1163,7 +1204,7 @@ class TestModelManager(unittest.TestCase):
 
 ```python
 def test_kvcached_memory_sharing():
-    """Test that models share GPU memory via KVCached."""
+    """Test that models share GPU memory via kvcached."""
 
     manager = ModelManager()
 
@@ -1211,7 +1252,7 @@ def test_kvcached_memory_sharing():
 
 If you encounter issues during implementation:
 
-1. **Check KVCached documentation** in this repository:
+1. **Check kvcached documentation** in this repository:
    - `docs/kvcached/README.md` - Overview
    - `docs/kvcached/architecture.md` - How it works
    - `docs/kvcached/cli-tools.md` - Memory management
@@ -1222,7 +1263,7 @@ If you encounter issues during implementation:
    echo $KVCACHED_AUTOPATCH     # Should be "1"
    ```
 
-3. **Check vLLM is using KVCached:**
+3. **Check vLLM is using kvcached:**
    ```bash
    kvctl list  # Should show IPC segments
    ```
@@ -1233,14 +1274,14 @@ If you encounter issues during implementation:
 
 ## Summary
 
-**Integration approach:** Direct vLLM instance management with KVCached enabled
+**Integration approach:** Direct vLLM instance management with kvcached enabled
 
 **Key decisions:**
-- ❌ Don't use KVCached Controller (too inflexible)
+- ❌ Don't use kvcached Controller (too inflexible)
 - ✅ Launch vLLM instances directly
 - ✅ Backend implements routing and lifecycle management
 - ✅ Use kvctl/kvtop for memory monitoring
-- ✅ KVCached provides GPU memory sharing automatically
+- ✅ kvcached provides GPU memory sharing automatically
 
 **Implementation roadmap:**
 1. Basic model management

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -42,7 +42,7 @@ export interface ModelMemoryMetricsDTO {
   cuda_graph_memory_gib: number
   /** Overhead memory (total - weights - CUDA graphs) in GiB */
   overhead_memory_gib: number
-  /** @deprecated KV cache available - meaningless with KVCached, kept for backwards compat */
+  /** @deprecated KV cache available - meaningless with kvcached, kept for backwards compat */
   kv_cache_available_gib: number
   kv_cache_per_request_mib: number
   max_model_len: number
@@ -66,7 +66,8 @@ export interface ModelInstanceDTO {
   launch_command?: string // Full vLLM command for debugging/reproduction
   gpu_ids: number[] // GPU indices this model is running on
   tensor_parallel_size: number // 1 = single GPU, >1 = spanning multiple GPUs
-  kvcached_enabled: boolean // Whether KVCached is enabled (false for tensor parallel)
+  kvcached_enabled: boolean // Whether kvcached is enabled (false for tensor parallel)
+  memory_baseline_by_gpu?: Record<number, number> // Memory baseline per GPU in GB
 }
 
 export interface GetModelResponse {
@@ -122,6 +123,7 @@ export interface PerGpuMetrics {
   free_gb: number
   utilization_percent: number
   models: ModelGpuMemory[]
+  kvcache?: KVCacheMetrics // Per-GPU KVCache metrics (undefined if no KVCache segment exists)
 }
 
 /** Multi-GPU memory usage response */

--- a/packages/types/src/benchmark.ts
+++ b/packages/types/src/benchmark.ts
@@ -62,7 +62,7 @@ export interface BenchmarkConfig {
   name?: string
   /** Execution mode: isolated or contention */
   mode: BenchmarkMode
-  /** Whether KVCached is enabled at system level */
+  /** Whether kvcached is enabled at system level */
   kvcachedEnabled: boolean
   /** Scenarios to run */
   scenarios: BenchmarkScenarioConfig[]

--- a/packages/types/src/memory-profile.ts
+++ b/packages/types/src/memory-profile.ts
@@ -39,7 +39,7 @@ export interface MemoryProfile {
   cudaGraphsGib: number
   /** Overhead memory (total - weights - CUDA graphs) in GiB */
   overheadMemoryGib: number
-  /** @deprecated KV cache available - meaningless with KVCached, kept for backwards compat */
+  /** @deprecated KV cache available - meaningless with kvcached, kept for backwards compat */
   kvCacheAvailableGib: number
   /** Estimated KV cache per request in MiB */
   kvCachePerRequestMib?: number

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -39,7 +39,7 @@ export interface ModelMemoryMetrics {
   cudaGraphMemoryGiB: number
   /** Overhead memory (total - weights - CUDA graphs) in GiB */
   overheadMemoryGiB: number
-  /** @deprecated KV cache available - meaningless with KVCached, kept for backwards compat */
+  /** @deprecated KV cache available - meaningless with kvcached, kept for backwards compat */
   kvCacheAvailableGiB: number
   /** KV cache memory per max-size request in MiB */
   kvCachePerRequestMiB: number
@@ -85,8 +85,10 @@ export interface ModelInstance {
   gpuIds: number[]
   /** Tensor parallel size (1 = single GPU, >1 = spanning multiple GPUs) */
   tensorParallelSize: number
-  /** Whether KVCached is enabled for this instance (disabled for tensor parallel) */
+  /** Whether kvcached is enabled for this instance (disabled for tensor parallel) */
   kvcachedEnabled: boolean
+  /** Memory baseline per GPU in GB (captured when model becomes 'running', before any inference) */
+  memoryBaselineByGpu: Record<number, number>
 }
 
 export interface InferenceRequest {

--- a/packages/types/src/schemas/benchmark.ts
+++ b/packages/types/src/schemas/benchmark.ts
@@ -22,10 +22,10 @@ export const RoutingModeSchema = Type.Union([Type.Literal('direct'), Type.Litera
 export const BenchmarkScenarioConfigSchema = Type.Object({
   instanceId: Type.String({ format: 'uuid' }),
   routingMode: Type.Optional(RoutingModeSchema),
-  inputTokens: Type.Integer({ minimum: 64, maximum: 4096, default: 512 }),
-  outputTokens: Type.Integer({ minimum: 16, maximum: 2048, default: 128 }),
-  concurrency: Type.Integer({ minimum: 1, maximum: 32, default: 1 }),
-  totalRequests: Type.Integer({ minimum: 10, maximum: 500, default: 50 }),
+  inputTokens: Type.Integer({ minimum: 64, maximum: 16384, default: 512 }),
+  outputTokens: Type.Integer({ minimum: 16, maximum: 32768, default: 128 }),
+  concurrency: Type.Integer({ minimum: 1, maximum: 100, default: 1 }),
+  totalRequests: Type.Integer({ minimum: 10, maximum: 5000, default: 50 }),
   warmupRequests: Type.Integer({ minimum: 0, maximum: 10, default: 3 }),
   slaThresholdMs: Type.Optional(Type.Number({ minimum: 100, maximum: 60000 })),
 })

--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -246,6 +246,13 @@ export const ModelGpuMemorySchema = Type.Object({
   color: Type.String(),
 })
 
+export const KVCacheMetricsSchema = Type.Object({
+  total_gb: Type.Number(),
+  prealloc_gb: Type.Number(),
+  used_gb: Type.Number(),
+  free_gb: Type.Number(),
+})
+
 export const PerGpuMetricsSchema = Type.Object({
   gpu_index: Type.Integer(),
   name: Type.String(),
@@ -254,13 +261,7 @@ export const PerGpuMetricsSchema = Type.Object({
   free_gb: Type.Number(),
   utilization_percent: Type.Number(),
   models: Type.Array(ModelGpuMemorySchema),
-})
-
-export const KVCacheMetricsSchema = Type.Object({
-  total_gb: Type.Number(),
-  prealloc_gb: Type.Number(),
-  used_gb: Type.Number(),
-  free_gb: Type.Number(),
+  kvcache: Type.Optional(KVCacheMetricsSchema),
 })
 
 export const MultiGpuMemoryUsageResponseSchema = Type.Object({

--- a/specs/001-multi-model-platform/contracts/controller-api.yaml
+++ b/specs/001-multi-model-platform/contracts/controller-api.yaml
@@ -38,7 +38,7 @@ paths:
       summary: Load a new model
       description: |
         Launch a new vLLM instance for the specified model. This operation:
-        1. Spawns a vLLM subprocess with KVCached enabled
+        1. Spawns a vLLM subprocess with kvcached enabled
         2. Waits for health endpoint to become available (timeout: 3 minutes)
         3. Returns instance details including port and status
 
@@ -176,7 +176,7 @@ paths:
         1. Sends SIGTERM to the vLLM process
         2. Waits up to 30 seconds for graceful shutdown
         3. Sends SIGKILL if process hasn't exited
-        4. Cleans up KVCached IPC segment via kvctl
+        4. Cleans up kvcached IPC segment via kvctl
 
         **Authorization**: Requires `admin` role.
 
@@ -457,7 +457,7 @@ components:
           description: Error message if status is failed
         ipc_segment_name:
           type: string
-          description: KVCached IPC segment name
+          description: kvcached IPC segment name
           example: VLLM_META_LLAMA_LLAMA_3_2_1B
 
     ResourceMetrics:

--- a/specs/001-multi-model-platform/data-model.md
+++ b/specs/001-multi-model-platform/data-model.md
@@ -52,7 +52,7 @@ Represents a running vLLM instance serving a specific model.
 | `loadedAt` | `Date` | ✅ | Timestamp when model started loading | ISO 8601 datetime |
 | `readyAt` | `Date` | ❌ | Timestamp when model became ready | ISO 8601 datetime, null if not ready |
 | `errorMessage` | `string` | ❌ | Error message if status is `failed` | Max 1000 characters |
-| `ipcSegmentName` | `string` | ✅ | KVCached IPC segment name | Computed from modelPath |
+| `ipcSegmentName` | `string` | ✅ | kvcached IPC segment name | Computed from modelPath |
 
 **Relationships:**
 - Many ModelInstances → One ModelConfiguration (N:1) - optional relationship

--- a/specs/001-multi-model-platform/plan.md
+++ b/specs/001-multi-model-platform/plan.md
@@ -20,7 +20,7 @@ Create a multi-model vLLM management platform that enables dynamic loading/unloa
 - **Frontend**: React + PatternFly 6 + TypeScript + Vite
 - **Monorepo**: npm workspaces (apps/backend, apps/frontend, packages/types)
 - **Container**: Based on `quay.io/vllm/vllm-cuda:0.11.2` with Node.js 22 added
-- **Process Management**: Direct subprocess spawning with KVCached memory sharing (NOT using KVCached Controller)
+- **Process Management**: Direct subprocess spawning with kvcached memory sharing (NOT using kvcached Controller)
 - **Auth**: OAuth 2.0 with RBAC (admin, admin-readonly roles)
 
 ## Technical Context
@@ -31,7 +31,7 @@ Create a multi-model vLLM management platform that enables dynamic loading/unloa
 - **Backend**: Fastify 5.1+, @fastify/swagger (OpenAPI), @fastify/oauth2 (auth), @fastify/jwt, prom-client (metrics)
 - **Frontend**: React 18.3+, PatternFly 6.0+, Vite 6.0+, react-router-dom 6.28+
 - **Shared**: @sinclair/typebox (schema validation), tsx (TypeScript execution)
-- **Infrastructure**: vLLM (model serving), KVCached (GPU memory sharing), NVIDIA CUDA 12.x
+- **Infrastructure**: vLLM (model serving), kvcached (GPU memory sharing), NVIDIA CUDA 12.x
 
 **Storage**: In-memory storage for PoC phase (Map data structures for ModelInstance, ResourceMetrics, InferenceRequest logs, ControllerOperation audit trail). Future: Config file for ModelConfiguration catalog, optional database for persistence.
 
@@ -56,7 +56,7 @@ Create a multi-model vLLM management platform that enables dynamic loading/unloa
 - Request throughput: Limited by vLLM instances, proxy adds <5% overhead
 
 **Constraints**:
-- GPU memory: Shared via KVCached, fair allocation required (prevent OOM)
+- GPU memory: Shared via kvcached, fair allocation required (prevent OOM)
 - No database dependency for PoC (in-memory storage acceptable)
 - OAuth 2.0 integration required from start (security by design)
 - OpenAI-compatible API format (enables drop-in replacement)
@@ -199,7 +199,7 @@ Create a multi-model vLLM management platform that enables dynamic loading/unloa
 **Pragmatic Choices**:
 - npm workspaces over pnpm/Turborepo (no additional tooling)
 - Fastify over NestJS (less abstraction, better performance)
-- Direct vLLM management over KVCached Controller (simpler, more flexible)
+- Direct vLLM management over kvcached Controller (simpler, more flexible)
 
 ---
 
@@ -260,7 +260,7 @@ specs/[###-feature]/
 │   │   │   │   └── proxy.ts       # Proxy API: /v1/completions, /v1/chat/completions
 │   │   │   ├── services/          # Business logic
 │   │   │   │   ├── model-manager.ts    # vLLM lifecycle (launch, unload, health)
-│   │   │   │   ├── memory-monitor.ts   # KVCached memory monitoring (kvctl integration)
+│   │   │   │   ├── memory-monitor.ts   # kvcached memory monitoring (kvctl integration)
 │   │   │   │   ├── metrics.ts          # Prometheus metrics collection
 │   │   │   │   └── proxy-router.ts     # Request routing to model instances
 │   │   │   └── plugins/           # Fastify plugins

--- a/specs/001-multi-model-platform/quickstart.md
+++ b/specs/001-multi-model-platform/quickstart.md
@@ -76,7 +76,7 @@ sardeenz/
 │   │   │   │   └── proxy.ts       # Proxy API routes
 │   │   │   ├── services/          # Business logic
 │   │   │   │   ├── model-manager.ts   # vLLM lifecycle management
-│   │   │   │   ├── memory-monitor.ts  # KVCached memory monitoring
+│   │   │   │   ├── memory-monitor.ts  # kvcached memory monitoring
 │   │   │   │   └── metrics.ts         # Prometheus metrics
 │   │   │   └── plugins/           # Fastify plugins
 │   │   │       ├── auth.ts        # OAuth 2.0 plugin
@@ -136,7 +136,7 @@ sardeenz/
 │   └── docker-compose.yml         # Development environment
 │
 ├── docs/                          # Documentation
-│   ├── kvcached/                  # KVCached integration docs
+│   ├── kvcached/                  # kvcached integration docs
 │   └── architecture.md            # System architecture (to be created)
 │
 ├── specs/                         # Feature specifications
@@ -167,7 +167,7 @@ sardeenz/
 - Handles Controller API (model lifecycle)
 - Handles Proxy API (inference routing)
 - Manages vLLM subprocesses
-- Integrates with KVCached for memory management
+- Integrates with kvcached for memory management
 
 **`apps/frontend/`**: React + PatternFly dashboard
 - Model management UI
@@ -230,7 +230,7 @@ API_BASE_URL=http://localhost:3000
 VLLM_BASE_PORT=12346
 VLLM_MAX_INSTANCES=10
 
-# KVCached Configuration
+# kvcached Configuration
 ENABLE_KVCACHED=true
 KVCACHED_AUTOPATCH=1
 
@@ -464,10 +464,10 @@ npm run start -w apps/backend
 npx serve apps/frontend/dist
 ```
 
-### Monitoring KVCached
+### Monitoring kvcached
 
 ```bash
-# List all KVCached IPC segments
+# List all kvcached IPC segments
 kvctl list
 
 # Monitor memory usage in real-time
@@ -502,7 +502,7 @@ tail -f apps/backend/logs/app.log
 **Possible Causes**:
 1. Insufficient GPU memory
 2. Model path incorrect or inaccessible
-3. KVCached not enabled
+3. kvcached not enabled
 4. vLLM binary not in PATH
 
 **Solutions**:
@@ -515,7 +515,7 @@ nvidia-smi
 which vllm
 vllm --version
 
-# Check KVCached environment variables
+# Check kvcached environment variables
 echo $ENABLE_KVCACHED  # Should be "true"
 echo $KVCACHED_AUTOPATCH  # Should be "1"
 
@@ -578,7 +578,7 @@ rm -rf apps/backend/.tsbuildinfo apps/frontend/.tsbuildinfo
 # Cmd/Ctrl + Shift + P → "TypeScript: Restart TS Server"
 ```
 
-### KVCached Segments Not Cleaned Up
+### kvcached Segments Not Cleaned Up
 
 **Symptom**: IPC segments remain after unloading models
 
@@ -611,5 +611,5 @@ kvctl list | grep VLLM | awk '{print $1}' | xargs -I {} kvctl delete {}
 
 - **Project Documentation**: `/docs` directory
 - **API Documentation**: http://localhost:3000/docs (when backend is running)
-- **KVCached Docs**: `/docs/kvcached` directory
+- **kvcached Docs**: `/docs/kvcached` directory
 - **Issue Tracker**: https://github.com/rh-aiservices-bu/sardeenz/issues

--- a/specs/001-multi-model-platform/research.md
+++ b/specs/001-multi-model-platform/research.md
@@ -7,7 +7,7 @@
 ## Table of Contents
 
 1. [Fastify Best Practices for TypeScript](#1-fastify-best-practices-for-typescript)
-2. [KVCached Subprocess Management](#2-kvcached-subprocess-management)
+2. [kvcached Subprocess Management](#2-kvcached-subprocess-management)
 3. [OAuth 2.0 Integration](#3-oauth-20-integration)
 4. [Streaming Proxy Implementation](#4-streaming-proxy-implementation)
 5. [Prometheus Metrics in Fastify](#5-prometheus-metrics-in-fastify)
@@ -108,12 +108,12 @@ fastify.post('/api/models/load', {
 
 ---
 
-## 2. KVCached Subprocess Management
+## 2. kvcached Subprocess Management
 
 ### Decision: Direct subprocess spawning with Node.js child_process
 
 **Rationale:**
-- KVCached Controller requires restart for model changes (unacceptable downtime)
+- kvcached Controller requires restart for model changes (unacceptable downtime)
 - Direct vLLM subprocess management provides full lifecycle control
 - Node.js `child_process` is sufficient, no need for Python wrapper
 - Documented in `docs/kvcached/sardeenz-integration.md` (comprehensive guide available)
@@ -150,12 +150,12 @@ export class ModelManager extends EventEmitter {
 
     const port = this.nextPort++
 
-    // Launch vLLM with KVCached enabled
+    // Launch vLLM with kvcached enabled
     const process = spawn('vllm', [
       'serve',
       modelPath,
       '--disable-log-requests',
-      '--no-enable-prefix-caching',  // Required for KVCached
+      '--no-enable-prefix-caching',  // Required for kvcached
       `--port=${port}`,
       `--gpu-memory-utilization=${gpuMemoryUtilization}`,
       `--max-model-len=${maxTokens}`,
@@ -258,15 +258,15 @@ export class ModelManager extends EventEmitter {
 ```
 
 **Key Environment Variables:**
-- `ENABLE_KVCACHED=true`: Enable KVCached memory sharing
-- `KVCACHED_AUTOPATCH=1`: Auto-patch vLLM for KVCached compatibility
+- `ENABLE_KVCACHED=true`: Enable kvcached memory sharing
+- `KVCACHED_AUTOPATCH=1`: Auto-patch vLLM for kvcached compatibility
 
 **Critical vLLM Flags:**
-- `--no-enable-prefix-caching`: Required for KVCached (incompatible otherwise)
+- `--no-enable-prefix-caching`: Required for kvcached (incompatible otherwise)
 - `--disable-log-requests`: Reduce noise in logs
 
 **Alternatives Considered:**
-- KVCached Controller: Rejected due to restart requirement for model changes
+- kvcached Controller: Rejected due to restart requirement for model changes
 - Python wrapper scripts: Unnecessary complexity, Node.js subprocess management is sufficient
 - Docker containers per model: Requires Docker-in-Docker, adds latency and complexity
 
@@ -953,7 +953,7 @@ export const ModelDashboard: React.FC = () => {
 | Area | Decision | Key Library/Tool | Rationale |
 |------|----------|------------------|-----------|
 | **Backend Framework** | Fastify with TypeScript | `fastify@^5.1.0` | Performance (<50ms routing), TypeScript support, OpenAPI integration |
-| **Process Management** | Direct subprocess | Node.js `child_process` | Full control, no downtime on model changes, KVCached compatible |
+| **Process Management** | Direct subprocess | Node.js `child_process` | Full control, no downtime on model changes, kvcached compatible |
 | **Authentication** | OAuth 2.0 | Manual OAuth flow | Enterprise-grade auth, RBAC via JWT claims, OpenShift OAuth compatible |
 | **Streaming Proxy** | Fastify reply.hijack() | Built-in | Minimal latency, direct TCP passthrough |
 | **Metrics** | Prometheus | `fastify-metrics@^11.0.0` | Industry standard, custom metrics support |
@@ -971,7 +971,7 @@ export const ModelDashboard: React.FC = () => {
 ## References
 
 - Fastify docs: https://fastify.dev/
-- KVCached integration guide: `/docs/kvcached/sardeenz-integration.md`
+- kvcached integration guide: `/docs/kvcached/sardeenz-integration.md`
 - PatternFly 6 docs: https://www.patternfly.org/
 - npm workspaces: https://docs.npmjs.com/cli/using-npm/workspaces
 - Constitution: `/.specify/memory/constitution.md`

--- a/specs/001-multi-model-platform/spec.md
+++ b/specs/001-multi-model-platform/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `001-multi-model-platform`
 **Created**: 2025-11-08
 **Status**: Draft
-**Input**: User description: "KVCached is a tool to help you launch and run multiple instances of vLLM to serve different Large Language Models. KVCached works from CLI commands, although it may also offer some API endpoints for control. The goal of our new application are multiple: 1) Provide a single endpoint to proxy requests to forward queries to the different vLLM endpoints listening on different ports. 2) Have a controller that you can query through an API to easily launch or stop models with KVCached. 3) Provide an admin UI to see which models are loaded, how much memory they consume, and call the controller API to load/unload models. 4) Package all of this in a single container image for easy deployment on OpenShift."
+**Input**: User description: "kvcached is a tool to help you launch and run multiple instances of vLLM to serve different Large Language Models. kvcached works from CLI commands, although it may also offer some API endpoints for control. The goal of our new application are multiple: 1) Provide a single endpoint to proxy requests to forward queries to the different vLLM endpoints listening on different ports. 2) Have a controller that you can query through an API to easily launch or stop models with kvcached. 3) Provide an admin UI to see which models are loaded, how much memory they consume, and call the controller API to load/unload models. 4) Package all of this in a single container image for easy deployment on OpenShift."
 
 ## Clarifications
 
@@ -19,7 +19,7 @@
 
 ### User Story 1 - Model Lifecycle Management via Controller API (Priority: P1)
 
-Platform operators need to dynamically launch and stop Large Language Model instances to manage resource usage and respond to changing workload demands. The controller API provides programmatic control over KVCached to start and stop model instances on demand.
+Platform operators need to dynamically launch and stop Large Language Model instances to manage resource usage and respond to changing workload demands. The controller API provides programmatic control over kvcached to start and stop model instances on demand.
 
 **Why this priority**: This is the foundation of the platform. Without the ability to manage model lifecycles, no other functionality can operate. This enables operators to respond to demand, manage costs, and optimize resource allocation.
 
@@ -27,7 +27,7 @@ Platform operators need to dynamically launch and stop Large Language Model inst
 
 **Acceptance Scenarios**:
 
-1. **Given** no models are currently running, **When** operator sends API request to launch a specific model (e.g., "llama-2-7b"), **Then** the system invokes KVCached to start the vLLM instance, returns success status, and the model becomes available on its designated port
+1. **Given** no models are currently running, **When** operator sends API request to launch a specific model (e.g., "llama-2-7b"), **Then** the system invokes kvcached to start the vLLM instance, returns success status, and the model becomes available on its designated port
 2. **Given** a model is currently running, **When** operator sends API request to stop that model, **Then** the system gracefully shuts down the vLLM instance, releases resources, and returns confirmation
 3. **Given** operator requests model status, **When** querying the controller API, **Then** system returns current state of all models (running, stopped, starting, stopping) with their port assignments
 4. **Given** operator attempts to launch a model that is already running, **When** the launch request is received, **Then** system returns an error indicating the model is already running without creating duplicate instances
@@ -93,7 +93,7 @@ Platform administrators need to deploy the entire multi-model management platfor
 - **Out of memory during model launch**: System validates available memory before launching and rejects requests with clear error if insufficient resources (see FR-026)
 - **Model crash during request routing**: Proxy detects unresponsive instances and returns timely error response rather than hanging (see FR-012)
 - **All model instances stopped**: Proxy returns clear error message indicating no models available with suggestions to check available models (see User Story 2, scenario 2)
-- **KVCached CLI unavailable or errors**: Controller returns clear error messages when model operations fail (see FR-007)
+- **kvcached CLI unavailable or errors**: Controller returns clear error messages when model operations fail (see FR-007)
 - **Port conflicts during launch**: System tracks port assignments and handles conflicts during model startup (see FR-005)
 - **Admin UI loses connection to controller**: UI displays connection error and provides retry mechanism
 - **Graceful shutdown during active requests**: Platform handles shutdown with hybrid approach to manage running processes and ongoing requests
@@ -104,7 +104,7 @@ Platform administrators need to deploy the entire multi-model management platfor
 
 #### Controller API Requirements
 
-- **FR-001**: System MUST provide API endpoint to launch a specified model using KVCached with model identifier
+- **FR-001**: System MUST provide API endpoint to launch a specified model using kvcached with model identifier
 - **FR-002**: System MUST provide API endpoint to stop a running model instance
 - **FR-003**: System MUST provide API endpoint to query status of all models (running, stopped, resource usage)
 - **FR-004**: System MUST support launching multiple instances of the same model, each with a unique instance identifier
@@ -137,7 +137,7 @@ Platform administrators need to deploy the entire multi-model management platfor
 - **FR-022**: System MUST package proxy, controller, and admin UI in a single container image
 - **FR-023**: System MUST be deployable on OpenShift without requiring external dependencies outside the container
 - **FR-024**: System MUST expose appropriate ports/services for proxy endpoint, controller API, and admin UI
-- **FR-025**: System MUST include KVCached and its dependencies within the container
+- **FR-025**: System MUST include kvcached and its dependencies within the container
 
 #### Resource Management & Observability Requirements
 
@@ -149,7 +149,7 @@ Platform administrators need to deploy the entire multi-model management platfor
 ### Key Entities
 
 - **Model Instance**: Represents a running or stopped Large Language Model with attributes including model identifier (e.g., "llama-2-7b"), unique instance identifier (to distinguish multiple instances of the same model), current status (running/stopped/starting/stopping), assigned port number, memory consumption, and start time
-- **Model Configuration**: Represents an available model that can be launched, including model identifier, resource requirements, and KVCached launch parameters
+- **Model Configuration**: Represents an available model that can be launched, including model identifier, resource requirements, and kvcached launch parameters
 - **Inference Request**: Represents a user request for model inference, including target model identifier, input prompt/data, and request metadata
 - **Resource Metrics**: Represents current resource usage for a model instance, including memory consumption, CPU usage (if available), request count, response times, and access to in-memory ring buffer of recent requests for debugging
 - **Controller Operation**: Represents an administrative action (launch, stop, status query) with operation type, target model, timestamp, and result status
@@ -174,8 +174,8 @@ Platform administrators need to deploy the entire multi-model management platfor
 
 ### Assumptions
 
-- KVCached is already installed and available within the container environment or can be packaged with the platform
-- vLLM is the inference engine used by KVCached; no other inference engines need support
+- kvcached is already installed and available within the container environment or can be packaged with the platform
+- vLLM is the inference engine used by kvcached; no other inference engines need support
 - OpenShift environment has sufficient resources (memory, CPU, GPU if needed) to run multiple model instances
 - Model files are either pre-downloaded within the container or accessible via network storage mounted to the container
 - Network latency between proxy and model instances is minimal (same host/container)
@@ -186,7 +186,7 @@ Platform administrators need to deploy the entire multi-model management platfor
 
 ### Dependencies
 
-- KVCached tool must be functional and able to launch vLLM instances
+- kvcached tool must be functional and able to launch vLLM instances
 - vLLM instances must expose HTTP/network endpoints for inference requests
 - OpenShift cluster must support container deployment with network routing
 - Sufficient system resources (memory, CPU, GPU) must be available to run multiple model instances simultaneously
@@ -203,6 +203,6 @@ The following are explicitly not included in this feature specification:
 - Request queuing or load balancing across multiple instances of the same model
 - Billing or usage tracking per user or per model
 - Integration with external model registries or catalogs
-- GPU allocation and management (assumed handled by KVCached and underlying infrastructure)
+- GPU allocation and management (assumed handled by kvcached and underlying infrastructure)
 - Backup and disaster recovery of platform state
 - Performance optimization beyond basic routing functionality

--- a/specs/001-multi-model-platform/tasks.md
+++ b/specs/001-multi-model-platform/tasks.md
@@ -109,7 +109,7 @@ This is a monorepo with npm workspaces:
 - [X] T042 [P] [US1] Create in-memory model instance store in apps/backend/src/stores/model-store.ts (Map<string, ModelInstance>)
 - [X] T043 [P] [US1] Create in-memory controller operation store in apps/backend/src/stores/operation-store.ts (circular buffer)
 - [X] T044 [US1] Implement ModelManager service in apps/backend/src/services/model-manager.ts with launchModel() method
-- [X] T045 [US1] Implement vLLM subprocess spawning with KVCached env vars in apps/backend/src/services/model-manager.ts
+- [X] T045 [US1] Implement vLLM subprocess spawning with kvcached env vars in apps/backend/src/services/model-manager.ts
 - [X] T046 [US1] Implement health check polling logic in apps/backend/src/services/model-manager.ts waitForReady() method
 - [X] T047 [US1] Implement unloadModel() with graceful shutdown (SIGTERM → SIGKILL) in apps/backend/src/services/model-manager.ts
 - [X] T048 [US1] Implement IPC segment cleanup via kvctl in apps/backend/src/services/model-manager.ts
@@ -262,7 +262,7 @@ This is a monorepo with npm workspaces:
 - [X] T136 [US4] Build frontend and serve via nginx in Dockerfile.unified
 - [X] T137 [US4] Configure container entrypoint to start backend server in Dockerfile.unified
 - [X] T138 [US4] Add health check for backend and frontend in Dockerfile.unified
-- [X] T139 [US4] Set environment variables for KVCached (ENABLE_KVCACHED, KVCACHED_AUTOPATCH) in Dockerfile.unified
+- [X] T139 [US4] Set environment variables for kvcached (ENABLE_KVCACHED, KVCACHED_AUTOPATCH) in Dockerfile.unified
 - [X] T140 [P] [US4] Create docker-compose.yml in docker/docker-compose.yml for local development
 - [X] T141 [US4] Configure service definitions for backend and frontend in docker-compose.yml
 - [X] T142 [US4] Add GPU device configuration in docker-compose.yml

--- a/specs/002-benchmarking/design-archive.md
+++ b/specs/002-benchmarking/design-archive.md
@@ -13,7 +13,7 @@ A benchmarking feature for sardeenz with two complementary capabilities:
 1. **Performance Benchmarking**: Measures LLM inference speed (TTFT, TPS, latency) across loaded models
 2. **Memory Profiling**: Measures baseline VRAM consumption for capacity planning and pre-load warnings
 
-Together, these provide quantitative data to answer critical questions about model performance, GPU memory efficiency, and the real-world impact of KVCached memory sharing.
+Together, these provide quantitative data to answer critical questions about model performance, GPU memory efficiency, and the real-world impact of kvcached memory sharing.
 
 ### Why Does This Matter?
 
@@ -21,7 +21,7 @@ Multi-model LLM deployment is complex. Teams need answers to:
 
 **Performance Questions:**
 - **"How fast is this model?"** - Baseline latency and throughput metrics
-- **"Is KVCached actually helping?"** - A/B comparison with/without memory sharing
+- **"Is kvcached actually helping?"** - A/B comparison with/without memory sharing
 - **"Can we handle production load?"** - Contention testing with concurrent models
 - **"Which model should we deploy?"** - Data-driven model selection
 
@@ -39,7 +39,7 @@ Without benchmarking and profiling, these decisions rely on guesswork. This feat
 | **ML Engineers** | Quantify model performance before production | Know exact VRAM requirements |
 | **Platform Operators** | Capacity planning with concurrency data | Pre-load warnings prevent OOM failures |
 | **Decision Makers** | Data-driven model selection | Cost optimization via memory awareness |
-| **KVCached Users** | Measure performance impact | Understand memory overhead per model |
+| **kvcached Users** | Measure performance impact | Understand memory overhead per model |
 
 ---
 
@@ -61,7 +61,7 @@ Without benchmarking and profiling, these decisions rely on guesswork. This feat
 |--------|------------------|----------------|
 | **Weights Memory** | Model parameters loaded to GPU | Fixed cost - cannot be reduced |
 | **CUDA Graphs** | Pre-compiled inference kernels | Fixed cost after warmup |
-| **KV Cache Available** | Memory pool for attention cache | Shared across all models (via KVCached) |
+| **KV Cache Available** | Memory pool for attention cache | Shared across all models (via kvcached) |
 | **KV Cache Per Request** | Estimated cache per concurrent request | Scales with max_tokens × concurrency |
 | **Baseline Memory** | Weights + CUDA Graphs | Minimum VRAM to load model |
 
@@ -119,11 +119,11 @@ Default: 3 warmup requests before measurement begins.
 
 ### Scenario B: KVCache A/B Testing
 
-**Goal:** Quantify the performance impact of KVCached memory sharing.
+**Goal:** Quantify the performance impact of kvcached memory sharing.
 
 **Setup:**
-1. Run benchmark with KVCached **enabled**
-2. Run identical benchmark with KVCached **disabled**
+1. Run benchmark with kvcached **enabled**
+2. Run identical benchmark with kvcached **disabled**
 3. Compare metrics side-by-side
 
 **Key Questions Answered:**
@@ -131,7 +131,7 @@ Default: 3 warmup requests before measurement begins.
 - How much memory is saved?
 - Is the tradeoff worth it?
 
-**Output:** Comparative metrics showing KVCached impact on TTFT, TPS, and memory.
+**Output:** Comparative metrics showing kvcached impact on TTFT, TPS, and memory.
 
 ---
 

--- a/specs/002-benchmarking/spec.md
+++ b/specs/002-benchmarking/spec.md
@@ -13,7 +13,7 @@ A benchmarking feature for sardeenz with two complementary capabilities:
 1. **Performance Benchmarking**: Measures LLM inference speed (TTFT, TPS, latency) across loaded models
 2. **Memory Profiling**: Measures baseline VRAM consumption for capacity planning and pre-load warnings
 
-Together, these provide quantitative data to answer critical questions about model performance, GPU memory efficiency, and the real-world impact of KVCached memory sharing.
+Together, these provide quantitative data to answer critical questions about model performance, GPU memory efficiency, and the real-world impact of kvcached memory sharing.
 
 ### Why Does This Matter?
 
@@ -22,7 +22,7 @@ Multi-model LLM deployment is complex. Teams need answers to:
 **Performance Questions:**
 
 - **"How fast is this model?"** - Baseline latency and throughput metrics
-- **"Is KVCached actually helping?"** - A/B comparison with/without memory sharing
+- **"Is kvcached actually helping?"** - A/B comparison with/without memory sharing
 - **"Can we handle production load?"** - Contention testing with concurrent models
 - **"Which model should we deploy?"** - Data-driven model selection
 
@@ -41,7 +41,7 @@ Without benchmarking and profiling, these decisions rely on guesswork. This feat
 | **ML Engineers** | Quantify model performance before production | Know exact VRAM requirements |
 | **Platform Operators** | Capacity planning with concurrency data | Pre-load warnings prevent OOM failures |
 | **Decision Makers** | Data-driven model selection | Cost optimization via memory awareness |
-| **KVCached Users** | Measure performance impact | Understand memory overhead per model |
+| **kvcached Users** | Measure performance impact | Understand memory overhead per model |
 
 ---
 
@@ -54,7 +54,7 @@ Without benchmarking and profiling, these decisions rely on guesswork. This feat
 | ML Engineer | As an ML Engineer, I want to measure baseline performance of a model so that I can establish a reference point before production | TTFT/TPS/E2E percentiles displayed for isolated single-model test |
 | ML Engineer | As an ML Engineer, I want to compare two models side-by-side so that I can choose the best one for my use case | Comparison view showing metrics for multiple models in same benchmark run |
 | Platform Operator | As a Platform Operator, I want to test performance under concurrent load so that I can validate capacity planning | Contention mode runs multiple models in parallel, reports per-model metrics |
-| Platform Operator | As a Platform Operator, I want to measure KVCached impact so that I can quantify the performance/memory tradeoff | Compare historical runs with/without KVCache using comparison view |
+| Platform Operator | As a Platform Operator, I want to measure kvcached impact so that I can quantify the performance/memory tradeoff | Compare historical runs with/without KVCache using comparison view |
 | Decision Maker | As a Decision Maker, I want to export benchmark results so that I can include them in reports | Export to CSV/JSON with all metrics and configuration |
 
 ### Memory Profiling
@@ -92,7 +92,7 @@ Without benchmarking and profiling, these decisions rely on guesswork. This feat
 |--------|------------------|----------------|
 | **Weights Memory** | Model parameters loaded to GPU | Fixed cost - cannot be reduced |
 | **CUDA Graphs** | Pre-compiled inference kernels | Fixed cost after warmup |
-| **KV Cache Available** | Memory pool for attention cache | Shared across all models (via KVCached) |
+| **KV Cache Available** | Memory pool for attention cache | Shared across all models (via kvcached) |
 | **KV Cache Per Request** | Estimated cache per concurrent request | Scales with max_tokens × concurrency |
 | **Baseline Memory** | Weights + CUDA Graphs | Minimum VRAM to load model |
 
@@ -154,12 +154,12 @@ Default: 3 warmup requests before measurement begins.
 
 ### Scenario B: KVCache Comparison (Historical)
 
-**Goal:** Compare performance with/without KVCached memory sharing.
+**Goal:** Compare performance with/without kvcached memory sharing.
 
 **Setup:**
 
-1. Run benchmark suite with KVCached **enabled** at system level
-2. Reconfigure system with KVCached **disabled**
+1. Run benchmark suite with kvcached **enabled** at system level
+2. Reconfigure system with kvcached **disabled**
 3. Run identical benchmark suite
 4. Use **Compare Runs** feature to overlay results
 
@@ -175,7 +175,7 @@ Default: 3 warmup requests before measurement begins.
 - How much memory is saved?
 - Is the tradeoff worth it?
 
-**Output:** Comparative metrics showing KVCached impact on TTFT, TPS, and memory.
+**Output:** Comparative metrics showing kvcached impact on TTFT, TPS, and memory.
 
 ---
 


### PR DESCRIPTION
Implement per-GPU memory tracking for accurate KVCache calculation in
multi-model and tensor-parallel configurations.

Changes:
- Add per-GPU IPC segment naming (kvcached_vllm_GPU0, kvcached_vllm_GPU0_GPU1)
- Track memory baseline at model load for accurate KVCache total calculation
- Calculate KVCache Total as: GPU Total - Model Baselines - Other Processes
- Add per-GPU kvcache metrics to /api/memory/usage/multi-gpu response
- Fix benchmark SSE auth by passing token via query parameter

Build infrastructure:
- Add Makefile for container builds (podman build/push)
- Rename Dockerfile.unified to Containerfile
- Update container to build kvcached from source

Documentation:
- Update kvcached integration docs for per-GPU IPC segments
- Update architecture and API docs with new memory metrics

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
