### PR TITLE
feat(auth): implement Kubernetes RBAC-based authorization

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -16,6 +16,12 @@ OAUTH_CLIENT_ID=sardeenz
 OAUTH_CLIENT_SECRET=change-me-in-production
 OAUTH_ISSUER_URL=
 K8S_API_URL=
+# Kubernetes namespace where sardeenz is deployed (for RBAC checks)
+NAMESPACE=sardeenz
+# ServiceAccount token for RBAC checks (required when AUTH_MODE=oauth)
+# In K8s: auto-mounted at /var/run/secrets/kubernetes.io/serviceaccount/token
+# For dev: generate with: oc create token sardeenz -n sardeenz --duration=8760h
+SERVICE_ACCOUNT_TOKEN=
 
 # JWT configuration
 JWT_SECRET=change-me-in-production

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -25,6 +25,9 @@ export interface Config {
   oauthClientSecret: string
   oauthIssuerUrl: string
   k8sApiUrl: string
+  namespace: string
+  serviceAccountToken: string
+  serviceAccountTokenPath: string
 
   // Inference API key (optional, for protecting inference endpoints separately)
   inferenceApiKey: string
@@ -116,6 +119,12 @@ export const config: Config = {
   oauthClientSecret: getEnv('OAUTH_CLIENT_SECRET', ''),
   oauthIssuerUrl: getEnv('OAUTH_ISSUER_URL', ''),
   k8sApiUrl: getEnv('K8S_API_URL', ''),
+  namespace: getEnv('NAMESPACE', 'sardeenz'),
+  serviceAccountToken: getEnv('SERVICE_ACCOUNT_TOKEN', ''),
+  serviceAccountTokenPath: getEnv(
+    'SERVICE_ACCOUNT_TOKEN_PATH',
+    '/var/run/secrets/kubernetes.io/serviceaccount/token'
+  ),
 
   // Inference API key (optional, for protecting inference endpoints separately)
   inferenceApiKey: getEnv('INFERENCE_API_KEY', ''),

--- a/apps/backend/src/plugins/auth.ts
+++ b/apps/backend/src/plugins/auth.ts
@@ -122,7 +122,7 @@ async function authPlugin(fastify: FastifyInstance) {
         reply.code(403).send({
           error: {
             message:
-              'Access denied: You are not a member of any authorized groups. Please contact your administrator to be added to sardeenz-admins or sardeenz-admins-readonly.',
+              'Access denied: You are not bound to any sardeenz roles. Contact your administrator to create a RoleBinding.',
             type: 'authorization_error',
             code: 'no_roles',
           },

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { Type, type Static } from '@sinclair/typebox'
 import { randomBytes, timingSafeEqual } from 'crypto'
+import { readFileSync, existsSync } from 'fs'
 import { config } from '../config.js'
 
 /**
@@ -86,16 +87,106 @@ function cleanupExpiredStates(): void {
 setInterval(cleanupExpiredStates, 60 * 1000)
 
 /**
- * Map OpenShift groups to application roles
+ * Get the ServiceAccount token for making K8s API calls
+ * Priority: 1) SERVICE_ACCOUNT_TOKEN env var, 2) Token file (K8s mounted)
+ * Returns undefined if neither is available
  */
-function mapGroupsToRoles(groups: string[]): string[] {
+function getServiceAccountToken(): string | undefined {
+  // Priority 1: Direct token from env var (for dev mode)
+  if (config.serviceAccountToken) {
+    return config.serviceAccountToken
+  }
+
+  // Priority 2: Token file (for K8s deployment)
+  if (existsSync(config.serviceAccountTokenPath)) {
+    return readFileSync(config.serviceAccountTokenPath, 'utf-8').trim()
+  }
+
+  return undefined
+}
+
+/**
+ * Check if a user has access to a specific sardeenz role via Kubernetes RBAC
+ * Uses LocalSubjectAccessReview API (namespace-scoped) to check role permissions
+ * Uses ServiceAccount token (not user's OAuth token) for the API call
+ */
+async function checkResourceAccess(
+  username: string,
+  groups: string[],
+  resource: string
+): Promise<boolean> {
+  const saToken = getServiceAccountToken()
+  if (!saToken) {
+    // Not running in K8s and no SA token configured
+    if (config.nodeEnv === 'development') {
+      // In dev mode without SA token, deny access (require proper setup)
+      return false
+    }
+    throw new Error(
+      'ServiceAccount token not found. Set SERVICE_ACCOUNT_TOKEN env var or ensure running in Kubernetes.'
+    )
+  }
+
+  // Use LocalSubjectAccessReview (namespace-scoped) instead of SubjectAccessReview (cluster-scoped)
+  // This only requires a namespace-scoped Role, not a ClusterRole
+  const response = await fetch(
+    `${config.k8sApiUrl}/apis/authorization.k8s.io/v1/namespaces/${config.namespace}/localsubjectaccessreviews`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${saToken}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        apiVersion: 'authorization.k8s.io/v1',
+        kind: 'LocalSubjectAccessReview',
+        metadata: {
+          namespace: config.namespace,
+        },
+        spec: {
+          user: username,
+          groups,
+          resourceAttributes: {
+            namespace: config.namespace,
+            group: 'sardeenz.rh-aiservices-bu.io',
+            resource,
+            verb: 'get',
+          },
+        },
+      }),
+    }
+  )
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`LocalSubjectAccessReview failed: ${response.status} - ${errorText}`)
+  }
+
+  const result = (await response.json()) as { status?: { allowed?: boolean } }
+  return result.status?.allowed === true
+}
+
+/**
+ * Resolve user roles via Kubernetes LocalSubjectAccessReview API
+ * Uses namespace-scoped Roles in the sardeenz namespace
+ */
+async function resolveUserRolesViaRbac(
+  username: string,
+  groups: string[]
+): Promise<string[]> {
   const roles: string[] = []
-  if (groups.includes('sardeenz-admins')) {
+
+  // Check admin role
+  if (await checkResourceAccess(username, groups, 'admin')) {
     roles.push('admin')
   }
-  if (groups.includes('sardeenz-admins-readonly')) {
+
+  // Check admin-readonly role
+  if (await checkResourceAccess(username, groups, 'admin-readonly')) {
     roles.push('admin-readonly')
   }
+
   return roles
 }
 
@@ -402,16 +493,19 @@ export default async function authRoutes(fastify: FastifyInstance) {
           'User info retrieved'
         )
 
-        // Map OpenShift groups to application roles
-        const roles = mapGroupsToRoles(userInfo.groups || [])
+        // Resolve user roles via Kubernetes RBAC (SubjectAccessReview)
+        const roles = await resolveUserRolesViaRbac(
+          userInfo.metadata.name,
+          userInfo.groups || []
+        )
 
         if (roles.length === 0) {
           fastify.log.warn(
             { username: userInfo.metadata.name, groups: userInfo.groups },
-            'User has no matching groups for access'
+            'User has no matching role bindings for access'
           )
           return reply.redirect(
-            `${config.frontendUrl}/?auth_error=${encodeURIComponent('Access denied: You are not a member of sardeenz-admins or sardeenz-admins-readonly groups.')}`
+            `${config.frontendUrl}/?auth_error=${encodeURIComponent('Access denied: You are not bound to sardeenz-admin or sardeenz-admin-readonly roles. Contact your administrator to create a RoleBinding.')}`
           )
         }
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -95,16 +95,35 @@ kubectl apply -k deployment/
 
 ```bash
 # Apply in this order
-oc apply -f deployment/pvc.yaml            # Optional: Only if downloading models from HuggingFace
-oc apply -f deployment/pvc-app-data.yaml   # Required: Application data (SQLite, cache)
+oc apply -f deployment/serviceaccount.yaml  # Required: ServiceAccount for RBAC
+oc apply -f deployment/rbac.yaml            # Required: RBAC roles and permissions
+oc apply -f deployment/pvc.yaml             # Optional: Only if downloading models from HuggingFace
+oc apply -f deployment/pvc-app-data.yaml    # Required: Application data (SQLite, cache)
 oc apply -f deployment/configmap.yaml
-oc apply -f deployment/secret.yaml         # Skip if using `oc create secret`
-oc apply -f deployment/deployment.yaml     # Must be adapted based on storage choices (see Storage section)
+oc apply -f deployment/secret.yaml          # Skip if using `oc create secret`
+oc apply -f deployment/deployment.yaml      # Must be adapted based on storage choices (see Storage section)
 oc apply -f deployment/service.yaml
 oc apply -f deployment/route.yaml
 ```
 
-### 6. Verify Deployment
+### 6. Configure RBAC (OAuth Mode Only)
+
+If using OAuth authentication (`AUTH_MODE=oauth`), you need to create RoleBindings to grant users access to sardeenz. The deployment manifests create the necessary Roles but not the user/group bindings.
+
+```bash
+# Give admin access to specific users
+oc adm policy add-role-to-user sardeenz-admin alice@company.com -n sardeenz
+
+# Give read-only access to all authenticated users
+oc adm policy add-role-to-group sardeenz-admin-readonly system:authenticated -n sardeenz
+
+# Give admin access to a group
+oc adm policy add-role-to-group sardeenz-admin platform-admins -n sardeenz
+```
+
+See [RBAC Setup Guide](../docs/rbac-setup.md) for complete configuration options.
+
+### 7. Verify Deployment
 
 ```bash
 # Check deployment status
@@ -124,11 +143,23 @@ oc get route sardeenz -n sardeenz -o jsonpath='{.spec.host}'
 
 ### Core Resources
 
+- **`serviceaccount.yaml`** - ServiceAccount for the sardeenz pod
+  - Used for RBAC authorization checks via LocalSubjectAccessReview
+  - Required for OAuth authentication mode
+
+- **`rbac.yaml`** - RBAC roles and permissions
+  - `sardeenz-admin` Role: Marker for full admin access
+  - `sardeenz-admin-readonly` Role: Marker for read-only access
+  - `sardeenz-auth-reviewer` Role: Allows ServiceAccount to check user permissions
+  - `sardeenz-auth-reviewer` RoleBinding: Binds ServiceAccount to auth-reviewer role
+  - See [RBAC Setup Guide](../docs/rbac-setup.md) for creating user/group bindings
+
 - **`deployment.yaml`** - Main application deployment with GPU resource requests
   - Configured for single replica (GPU constraint)
   - GPU node selector and tolerations
   - Liveness, readiness, and startup probes
   - Environment variables from ConfigMap and Secret
+  - Uses `sardeenz` ServiceAccount for RBAC
 
 - **`service.yaml`** - ClusterIP service exposing backend (3000) and frontend (80)
 

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app.kubernetes.io/name: sardeenz
         app.kubernetes.io/component: ml-platform
     spec:
+      # ServiceAccount for RBAC checks (LocalSubjectAccessReview)
+      serviceAccountName: sardeenz
+
       # GPU node selector - target nodes with NVIDIA GPUs
       nodeSelector:
         nvidia.com/gpu.present: "true"
@@ -131,6 +134,11 @@ spec:
                   name: sardeenz-secrets
                   key: k8s-api-url
                   optional: true
+            # Namespace for RBAC checks (uses downward API)
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 
             # Inference API key (optional)
             - name: INFERENCE_API_KEY

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -14,6 +14,8 @@ commonLabels:
 
 # Resources to deploy
 resources:
+  - serviceaccount.yaml
+  - rbac.yaml
   - pvc.yaml
   - pvc-app-data.yaml
   - configmap.yaml

--- a/deployment/rbac.yaml
+++ b/deployment/rbac.yaml
@@ -1,0 +1,87 @@
+# =============================================================================
+# Sardeenz RBAC Configuration
+# =============================================================================
+# This file contains the RBAC resources needed for sardeenz OAuth authentication.
+#
+# Included:
+# - sardeenz-admin Role: Marker permission for full admin access
+# - sardeenz-admin-readonly Role: Marker permission for read-only access
+# - sardeenz-auth-reviewer Role: Allows ServiceAccount to check user permissions
+# - sardeenz-auth-reviewer RoleBinding: Binds the ServiceAccount to the reviewer role
+#
+# NOT included (must be created separately):
+# - RoleBindings for users/groups to sardeenz-admin or sardeenz-admin-readonly
+#   See docs/rbac-setup.md for examples
+# =============================================================================
+
+---
+# Role: sardeenz-admin
+# Grants full admin access to sardeenz (load/unload models, run benchmarks, etc.)
+# This is a "marker" role - the resource doesn't actually exist, it's only used
+# for authorization checks via LocalSubjectAccessReview.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sardeenz-admin
+  labels:
+    app: sardeenz
+    app.kubernetes.io/name: sardeenz
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["sardeenz.rh-aiservices-bu.io"]
+    resources: ["admin"]
+    verbs: ["get"]
+
+---
+# Role: sardeenz-admin-readonly
+# Grants read-only access to sardeenz (view models, benchmarks, settings)
+# This is a "marker" role - the resource doesn't actually exist, it's only used
+# for authorization checks via LocalSubjectAccessReview.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sardeenz-admin-readonly
+  labels:
+    app: sardeenz
+    app.kubernetes.io/name: sardeenz
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["sardeenz.rh-aiservices-bu.io"]
+    resources: ["admin-readonly"]
+    verbs: ["get"]
+
+---
+# Role: sardeenz-auth-reviewer
+# Allows the sardeenz ServiceAccount to create LocalSubjectAccessReviews
+# This is required for checking user permissions via the Kubernetes API
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sardeenz-auth-reviewer
+  labels:
+    app: sardeenz
+    app.kubernetes.io/name: sardeenz
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["localsubjectaccessreviews"]
+    verbs: ["create"]
+
+---
+# RoleBinding: sardeenz-auth-reviewer
+# Binds the sardeenz ServiceAccount to the auth-reviewer role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sardeenz-auth-reviewer
+  labels:
+    app: sardeenz
+    app.kubernetes.io/name: sardeenz
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sardeenz-auth-reviewer
+subjects:
+  - kind: ServiceAccount
+    name: sardeenz

--- a/deployment/serviceaccount.yaml
+++ b/deployment/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sardeenz
+  labels:
+    app: sardeenz
+    app.kubernetes.io/name: sardeenz
+    app.kubernetes.io/component: ml-platform

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 | [**Frontend Architecture**](./architecture/frontend-architecture.md) | Frontend component specs, state management, and API integration         |
 | [**API Guide**](./api-guide.md)                                      | API reference with code examples for Controller and Proxy APIs          |
 | [**Deployment Guide**](./deployment.md)                              | Container building and OpenShift/Kubernetes deployment                  |
+| [**RBAC Setup**](./rbac-setup.md)                                    | Kubernetes-native RBAC configuration for OAuth authentication           |
 
 ### 🛠️ Development Guides
 
@@ -75,6 +76,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 **Deploying and managing the platform?**
 
 - [Deployment Guide](./deployment.md) - Container build and OpenShift deployment
+- [RBAC Setup Guide](./rbac-setup.md) - Kubernetes-native RBAC for OAuth authentication
 - [Deployment Guide: Configuration](./deployment.md#configuration) - Environment variables
 - [Deployment Guide: Monitoring](./deployment.md#monitoring) - Prometheus metrics setup
 - [Deployment Guide: Troubleshooting](./deployment.md#troubleshooting) - Common issues
@@ -84,7 +86,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 - GPU-enabled OpenShift cluster setup
 - App Data PVC (required for SQLite)
 - Model storage: HuggingFace cache PVC or local/mounted models (see [deployment/README.md](../deployment/README.md#storage-configuration))
-- OAuth 2.0 integration (OpenShift OAuth)
+- OAuth 2.0 integration with Kubernetes RBAC (see [rbac-setup.md](./rbac-setup.md))
 
 ### 📊 Data Scientists / ML Engineers
 
@@ -141,6 +143,7 @@ Welcome to the Sardeenz documentation! This directory contains comprehensive gui
 | Document                         | Topics Covered                                                                                                   |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | [deployment.md](./deployment.md) | Container build, Docker Compose, OpenShift deployment, configuration, health checks, monitoring, troubleshooting |
+| [rbac-setup.md](./rbac-setup.md) | Kubernetes-native RBAC setup for OAuth mode, Role/RoleBinding configuration, ServiceAccount permissions          |
 | [kvcached/](./kvcached/)         | kvcached installation, configuration, memory segment management                                                  |
 
 ### Development Guides
@@ -309,7 +312,7 @@ Set the `AUTH_MODE` environment variable:
 - `K8S_API_URL=<kubernetes-api-url>`
 - `JWT_SECRET=<your-secret>`
 
-Roles are assigned via OpenShift groups: `sardeenz-admins` (full access) and `sardeenz-admins-readonly` (read-only).
+Roles are assigned via Kubernetes RoleBindings. See [rbac-setup.md](./rbac-setup.md) for complete RBAC configuration.
 
 See [api-guide.md](./api-guide.md#authentication) and [deployment.md](./deployment.md#configuration) for details.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -492,50 +492,23 @@ oc logs -f deployment/sardeenz -n sardeenz
 
 Sardeenz supports three authentication modes for the admin dashboard:
 
-| Mode     | Use Case                       | Configuration                              |
-| -------- | ------------------------------ | ------------------------------------------ |
-| `none`   | Development, testing           | No auth required                           |
-| `simple` | Single-admin deployments       | Username/password with JWT                 |
-| `oauth`  | Enterprise with OpenShift SSO  | OpenShift OAuth 2.0 with group-based RBAC  |
+| Mode     | Use Case                       | Configuration                                      |
+| -------- | ------------------------------ | -------------------------------------------------- |
+| `none`   | Development, testing           | No auth required                                   |
+| `simple` | Single-admin deployments       | Username/password with JWT                         |
+| `oauth`  | Enterprise with OpenShift SSO  | OpenShift OAuth 2.0 with Kubernetes-native RBAC    |
 
 ### OpenShift OAuth Setup
 
-For production deployments, OAuth mode integrates with OpenShift's authentication system and uses group membership for role-based access control.
+For production deployments, OAuth mode integrates with OpenShift's authentication system and uses Kubernetes-native RBAC for role-based access control.
 
-#### 1. Create OpenShift Groups
+**Key Benefits:**
 
-Users must belong to specific OpenShift groups to access the dashboard:
+- **No cluster-admin required** - Deployment only needs namespace-level permissions
+- **Dynamic access management** - Add/remove users via RoleBindings without restarting sardeenz
+- **Flexible binding** - Assign roles to users, groups, or all authenticated users
 
-| Group                      | Role             | Access Level            |
-| -------------------------- | ---------------- | ----------------------- |
-| `sardeenz-admins`          | `admin`          | Full read/write access  |
-| `sardeenz-admins-readonly` | `admin-readonly` | Read-only access        |
-
-**Create the groups:**
-
-```bash
-# Create admin group (full access)
-oc adm groups new sardeenz-admins
-
-# Create read-only group
-oc adm groups new sardeenz-admins-readonly
-```
-
-#### 2. Add Users to Groups
-
-```bash
-# Add users to admin group
-oc adm groups add-users sardeenz-admins user1@example.com user2@example.com
-
-# Add users to read-only group
-oc adm groups add-users sardeenz-admins-readonly readonly-user@example.com
-
-# Verify group membership
-oc get group sardeenz-admins -o yaml
-oc get group sardeenz-admins-readonly -o yaml
-```
-
-#### 3. Create OAuth Client
+#### 1. Create OAuth Client
 
 Register Sardeenz as an OAuth client with OpenShift:
 
@@ -556,7 +529,7 @@ secret: your-oauth-client-secret
 oc apply -f oauth-client.yaml
 ```
 
-#### 4. Configure Environment Variables
+#### 2. Configure Environment Variables
 
 ```bash
 # Create OAuth secret
@@ -574,35 +547,62 @@ oc create secret generic jwt-config \
 
 Add to deployment (see example in OpenShift Deployment section above).
 
-### Access Denied Handling
+#### 3. Configure RBAC
 
-When a user authenticates via OAuth but is not a member of either `sardeenz-admins` or `sardeenz-admins-readonly`:
+Sardeenz uses Kubernetes-native RBAC to control access. Create Roles and RoleBindings to grant users access to the dashboard.
 
-1. **Authentication succeeds** - User is verified by OpenShift
-2. **Authorization fails** - User lacks required group membership
-3. **Access Denied page** - User is redirected to an informative error page
+**For complete RBAC configuration instructions, see [RBAC Setup Guide](./rbac-setup.md).**
 
-The Access Denied page explains:
-
-- The user is not in any authorized groups
-- Which groups are required (`sardeenz-admins` or `sardeenz-admins-readonly`)
-- Instructions to contact an OpenShift administrator
-
-**To grant access:** An OpenShift cluster administrator must add the user to one of the authorized groups:
+Quick example - give read-only access to all authenticated users:
 
 ```bash
-# Grant full admin access
-oc adm groups add-users sardeenz-admins user@example.com
+# Apply the sardeenz Roles
+oc apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sardeenz-admin-readonly
+  namespace: sardeenz
+rules:
+  - apiGroups: ["sardeenz.rh-aiservices-bu.io"]
+    resources: ["admin-readonly"]
+    verbs: ["get"]
+EOF
 
-# Grant read-only access
-oc adm groups add-users sardeenz-admins-readonly user@example.com
+# Bind to all authenticated users
+oc adm policy add-role-to-group sardeenz-admin-readonly system:authenticated -n sardeenz
 ```
 
-After being added to a group, the user can click "Try Again" on the Access Denied page to re-authenticate.
+### Access Denied Handling
+
+When a user authenticates via OAuth but is not bound to either `sardeenz-admin` or `sardeenz-admin-readonly` roles:
+
+1. **Authentication succeeds** - User is verified by OpenShift
+2. **Authorization fails** - User lacks required RoleBinding
+3. **Access Denied page** - User is redirected to an informative error page
+
+**To grant access:** Create a RoleBinding for the user or their group:
+
+```bash
+# Grant full admin access to a user
+oc adm policy add-role-to-user sardeenz-admin user@example.com -n sardeenz
+
+# Grant read-only access to a group
+oc adm policy add-role-to-group sardeenz-admin-readonly team-name -n sardeenz
+```
+
+After creating the RoleBinding, the user can click "Try Again" on the Access Denied page to re-authenticate.
 
 ### RBAC Permissions
 
-For detailed permissions by role, see [API Guide: RBAC Roles](./api-guide.md#rbac-roles).
+| Role             | Access Level                                                  |
+| ---------------- | ------------------------------------------------------------- |
+| `admin`          | Full access - load/unload models, run benchmarks, settings    |
+| `admin-readonly` | Read-only - view models, benchmarks, settings (no mutations)  |
+
+For detailed RBAC setup including ServiceAccount permissions, see [RBAC Setup Guide](./rbac-setup.md).
+
+For API permissions by role, see [API Guide: RBAC Roles](./api-guide.md#rbac-roles).
 
 ## Configuration
 
@@ -821,31 +821,33 @@ oc exec -it <pod-name> -- env | grep -E 'ADMIN_USERNAME|ADMIN_PASSWORD'
 
 **5. Authorization Errors (Access Denied)**
 
-If users see the Access Denied page after OAuth login, they have successfully authenticated but are not members of any authorized groups.
+If users see the Access Denied page after OAuth login, they have successfully authenticated but are not bound to any sardeenz roles.
 
 ```bash
-# Check user's group membership
-oc get users <username> -o yaml
+# Check if the Roles exist
+oc get role sardeenz-admin sardeenz-admin-readonly -n sardeenz
 
-# List members of sardeenz groups
-oc get group sardeenz-admins -o yaml
-oc get group sardeenz-admins-readonly -o yaml
+# Check existing RoleBindings
+oc get rolebindings -n sardeenz -o wide
 
-# Add user to appropriate group
-oc adm groups add-users sardeenz-admins <username>
+# Test access with impersonation
+oc auth can-i get admin.sardeenz.rh-aiservices-bu.io -n sardeenz --as=user@example.com
 
-# Verify the groups exist
-oc get groups | grep sardeenz
+# Add user to appropriate role
+oc adm policy add-role-to-user sardeenz-admin <username> -n sardeenz
+
+# Or add a group
+oc adm policy add-role-to-group sardeenz-admin-readonly team-name -n sardeenz
 ```
 
 **Common issues:**
 
-- **User not in any authorized group** → Add user to `sardeenz-admins` or `sardeenz-admins-readonly`
-- **Groups don't exist** → Create groups with `oc adm groups new sardeenz-admins`
-- **Group names misspelled** → Must be exactly `sardeenz-admins` or `sardeenz-admins-readonly`
+- **Roles don't exist** → Create Roles first (see [RBAC Setup Guide](./rbac-setup.md#step-1-create-the-roles))
+- **No RoleBinding for user/group** → Create RoleBinding with `oc adm policy add-role-to-user` or `add-role-to-group`
+- **ServiceAccount token missing** → Check `sardeenz-auth-reviewer` Role/RoleBinding exists
 - **K8S_API_URL incorrect** → Verify URL and connectivity from pod
 
-**Solution:** Add user to the appropriate group, then have them click "Try Again" on the Access Denied page to re-authenticate.
+**Solution:** Create a RoleBinding for the user or their group, then have them click "Try Again" on the Access Denied page. See [RBAC Setup Guide](./rbac-setup.md) for complete setup instructions.
 
 ### Debug Mode
 
@@ -867,4 +869,5 @@ oc logs -f deployment/sardeenz | jq .
 
 - [Architecture](./architecture.md) - System architecture and design
 - [API Guide](./api-guide.md) - API usage examples
+- [RBAC Setup](./rbac-setup.md) - Kubernetes-native RBAC configuration for OAuth
 - [kvcached Documentation](./kvcached/) - GPU memory sharing setup

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -165,6 +165,140 @@ npm run dev -w apps/frontend
 
 The backend will start but model loading will fail without GPU/vLLM.
 
+## Developing with OAuth Authentication
+
+If you want to test OAuth authentication locally against a remote OpenShift cluster, follow these steps.
+
+### Prerequisites
+
+- Access to an OpenShift cluster with OAuth configured
+- `oc` CLI logged in with namespace admin permissions
+- A namespace for sardeenz RBAC resources (e.g., `sardeenz`)
+
+### Step 1: Create OAuth Client on OpenShift
+
+Register a development OAuth client with localhost callback URL:
+
+```bash
+oc apply -f - <<EOF
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: sardeenz-dev
+grantMethod: auto
+redirectURIs:
+  - http://localhost:3000/api/auth/callback
+secret: dev-secret-change-me
+EOF
+```
+
+> **Note:** Change the `secret` value to something unique for your development environment.
+
+### Step 2: Create RBAC Resources on OpenShift
+
+Create the namespace and apply the RBAC manifests from the deployment folder:
+
+```bash
+# Create namespace (if it doesn't exist)
+oc new-project sardeenz
+
+# Apply ServiceAccount and RBAC resources
+oc apply -f deployment/serviceaccount.yaml -n sardeenz
+oc apply -f deployment/rbac.yaml -n sardeenz
+```
+
+This creates:
+- The `sardeenz` ServiceAccount
+- The `sardeenz-admin` and `sardeenz-admin-readonly` marker Roles
+- The `sardeenz-auth-reviewer` Role and RoleBinding
+
+### Step 3: Create RoleBinding for Your User
+
+Grant yourself admin access:
+
+```bash
+oc adm policy add-role-to-user sardeenz-admin $(oc whoami) -n sardeenz
+```
+
+For complete RBAC configuration options (adding other users, groups, or all authenticated users), see the [RBAC Setup Guide](./rbac-setup.md).
+
+> **Note for Cluster-Admin Users:** If you're logged in as a cluster-admin, you will automatically have access to sardeenz regardless of whether you have a sardeenz-admin RoleBinding. This is expected Kubernetes RBAC behavior—cluster-admin has wildcard permissions on all resources including sardeenz marker roles. To properly test RBAC authorization (denied access, read-only vs admin), use a non-cluster-admin account.
+
+### Step 4: Generate ServiceAccount Token
+
+Generate a long-lived token for local development:
+
+```bash
+oc create token sardeenz -n sardeenz --duration=8760h
+```
+
+Save this token - you'll need it for the environment variable.
+
+### Step 5: Configure Environment Variables
+
+Create or update `apps/backend/.env` with the OAuth configuration:
+
+```bash
+# Authentication mode
+AUTH_MODE=oauth
+
+# OAuth client configuration (must match the OAuthClient created above)
+OAUTH_CLIENT_ID=sardeenz-dev
+OAUTH_CLIENT_SECRET=dev-secret-change-me
+
+# OpenShift URLs
+OAUTH_ISSUER_URL=https://oauth-openshift.apps.your-cluster.com
+K8S_API_URL=https://api.your-cluster.com:6443
+
+# RBAC configuration
+NAMESPACE=sardeenz
+SERVICE_ACCOUNT_TOKEN=<paste token from Step 4>
+
+# Local development URLs
+API_BASE_URL=http://localhost:3000
+FRONTEND_URL=http://localhost:5173
+
+# JWT secret (any random string for development)
+JWT_SECRET=your-dev-jwt-secret-change-me
+```
+
+### Getting the OpenShift URLs
+
+To find the correct URLs for your cluster:
+
+```bash
+# Get the Kubernetes API URL
+oc whoami --show-server
+# Example output: https://api.your-cluster.com:6443
+
+# The OAuth issuer URL is typically derived from the API URL
+# Replace 'api.' with 'oauth-openshift.apps.' and remove the port
+# Example: https://oauth-openshift.apps.your-cluster.com
+```
+
+### Step 6: Start Development
+
+```bash
+npm run dev
+```
+
+Navigate to `http://localhost:5173`. When you click "Login", you'll be redirected to OpenShift OAuth, then back to the local frontend with your session authenticated.
+
+### Troubleshooting OAuth Development
+
+**"Access denied" after login:**
+- Verify your RoleBinding exists: `oc get rolebindings -n sardeenz`
+- Check if you have the right role: `oc auth can-i get admin.sardeenz.rh-aiservices-bu.io -n sardeenz --as=$(oc whoami)`
+
+**"LocalSubjectAccessReview failed" errors:**
+- Check that the `sardeenz-auth-reviewer` RoleBinding exists
+- Verify your SERVICE_ACCOUNT_TOKEN is valid and not expired
+- Ensure K8S_API_URL is correct and reachable from your machine
+
+**"Invalid redirect URI" from OpenShift:**
+- Verify the OAuthClient has `http://localhost:3000/api/auth/callback` in redirectURIs
+- Ensure API_BASE_URL matches exactly
+
 ## Troubleshooting
 
 ### "uv is not installed"
@@ -229,4 +363,5 @@ kvctl limit <segment-name> 4G
 
 - [Architecture Documentation](./architecture.md) - System design and vLLM integration
 - [API Guide](./api-guide.md) - Model loading API endpoints
+- [RBAC Setup Guide](./rbac-setup.md) - Kubernetes-native RBAC configuration for OAuth
 - [kvcached Documentation](./kvcached/) - Detailed kvcached configuration

--- a/docs/rbac-setup.md
+++ b/docs/rbac-setup.md
@@ -1,0 +1,340 @@
+# RBAC Setup for sardeenz
+
+This guide explains how to configure Role-Based Access Control (RBAC) for sardeenz when using OAuth authentication with OpenShift.
+
+## Overview
+
+sardeenz uses Kubernetes-native RBAC to control access. When a user authenticates via OAuth:
+
+1. sardeenz queries the Kubernetes LocalSubjectAccessReview API (namespace-scoped)
+2. It checks if the user has permissions to access sardeenz roles
+3. Based on the RBAC bindings, the user is assigned `admin` and/or `admin-readonly` roles
+
+This approach allows you to manage access via standard OpenShift tooling without restarting sardeenz. All permissions are namespace-scoped, so no cluster-admin is required for deployment.
+
+## What's Included in the Deployment
+
+The deployment manifests in `deployment/` already include:
+
+| Resource | File | Description |
+|----------|------|-------------|
+| **ServiceAccount** | `serviceaccount.yaml` | The `sardeenz` ServiceAccount used by the pod |
+| **sardeenz-admin Role** | `rbac.yaml` | Marker role for full admin access |
+| **sardeenz-admin-readonly Role** | `rbac.yaml` | Marker role for read-only access |
+| **sardeenz-auth-reviewer Role** | `rbac.yaml` | Allows ServiceAccount to check user permissions |
+| **sardeenz-auth-reviewer RoleBinding** | `rbac.yaml` | Binds ServiceAccount to auth-reviewer role |
+
+**What you need to create:** RoleBindings to grant users/groups access to sardeenz (see [Step 2](#step-2-create-rolebindings)).
+
+## Prerequisites
+
+- OpenShift cluster with OAuth configured
+- `oc` CLI with namespace admin permissions (no cluster-admin required)
+- sardeenz deployed with `AUTH_MODE=oauth` (using the manifests in `deployment/`)
+
+## Step 1: Create the Roles
+
+> **Note:** If you deployed sardeenz using the manifests in `deployment/`, these Roles are already created by `rbac.yaml`. Skip to [Step 2](#step-2-create-rolebindings).
+
+Create the sardeenz Roles in your deployment namespace. These Roles define "marker" permissions that sardeenz checks via LocalSubjectAccessReview.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sardeenz-admin
+  namespace: sardeenz  # Change to your namespace
+rules:
+  - apiGroups: ["sardeenz.rh-aiservices-bu.io"]
+    resources: ["admin"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sardeenz-admin-readonly
+  namespace: sardeenz  # Change to your namespace
+rules:
+  - apiGroups: ["sardeenz.rh-aiservices-bu.io"]
+    resources: ["admin-readonly"]
+    verbs: ["get"]
+```
+
+Apply with:
+
+```bash
+oc apply -f roles.yaml -n sardeenz
+```
+
+These are "marker" permissions - the resources don't actually exist. They're only used for LocalSubjectAccessReview authorization checks.
+
+## Step 2: Create RoleBindings
+
+Bind users, groups, or ServiceAccounts to the Roles.
+
+### Give admin access to specific users
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sardeenz-admins
+  namespace: sardeenz
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sardeenz-admin
+subjects:
+  - kind: User
+    name: alice@company.com
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: bob@company.com
+    apiGroup: rbac.authorization.k8s.io
+```
+
+Or using the CLI:
+
+```bash
+oc adm policy add-role-to-user sardeenz-admin alice@company.com -n sardeenz
+oc adm policy add-role-to-user sardeenz-admin bob@company.com -n sardeenz
+```
+
+### Give admin access to a group
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sardeenz-admins-group
+  namespace: sardeenz
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sardeenz-admin
+subjects:
+  - kind: Group
+    name: platform-admins
+    apiGroup: rbac.authorization.k8s.io
+```
+
+Or using the CLI:
+
+```bash
+oc adm policy add-role-to-group sardeenz-admin platform-admins -n sardeenz
+```
+
+### Give read-only access to all authenticated users
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sardeenz-readonly-all
+  namespace: sardeenz
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sardeenz-admin-readonly
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+```
+
+Or using the CLI:
+
+```bash
+oc adm policy add-role-to-group sardeenz-admin-readonly system:authenticated -n sardeenz
+```
+
+### Give read-only access to specific groups
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sardeenz-readonly-teams
+  namespace: sardeenz
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sardeenz-admin-readonly
+subjects:
+  - kind: Group
+    name: team-a
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: team-b
+    apiGroup: rbac.authorization.k8s.io
+```
+
+Or using the CLI:
+
+```bash
+oc adm policy add-role-to-group sardeenz-admin-readonly team-a -n sardeenz
+oc adm policy add-role-to-group sardeenz-admin-readonly team-b -n sardeenz
+```
+
+## Step 3: ServiceAccount Permissions
+
+> **Note:** If you deployed sardeenz using the manifests in `deployment/`, the ServiceAccount (`serviceaccount.yaml`) and auth-reviewer permissions (`rbac.yaml`) are already created. Skip to [Development Mode Setup](#development-mode-setup) if running locally.
+
+sardeenz uses a ServiceAccount to query the LocalSubjectAccessReview API (namespace-scoped). The ServiceAccount needs permission to create LocalSubjectAccessReviews in the sardeenz namespace.
+
+### Create the ServiceAccount
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sardeenz
+  namespace: sardeenz  # Change to your namespace
+```
+
+### Create the Role and RoleBinding
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sardeenz-auth-reviewer
+  namespace: sardeenz  # Change to your namespace
+rules:
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["localsubjectaccessreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sardeenz-auth-reviewer
+  namespace: sardeenz  # Change to your namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sardeenz-auth-reviewer
+subjects:
+  - kind: ServiceAccount
+    name: sardeenz
+    namespace: sardeenz  # Change to your namespace
+```
+
+Apply with:
+
+```bash
+oc apply -f serviceaccount.yaml -n sardeenz
+oc apply -f sa-permissions.yaml -n sardeenz
+```
+
+### Use the ServiceAccount in the Deployment
+
+Ensure your Deployment references the ServiceAccount:
+
+```yaml
+spec:
+  template:
+    spec:
+      serviceAccountName: sardeenz
+      # ... rest of pod spec
+```
+
+**Note:** This uses namespace-scoped permissions only - no cluster-admin required for deployment.
+
+## Development Mode Setup
+
+When running sardeenz locally (outside of Kubernetes), you need to provide a ServiceAccount token manually.
+
+### Generate a token for local development
+
+```bash
+# Create a long-lived token for the sardeenz ServiceAccount
+oc create token sardeenz -n sardeenz --duration=8760h
+```
+
+### Set the token in your environment
+
+Add to your `.env` file or export:
+
+```bash
+export SERVICE_ACCOUNT_TOKEN="<token from above>"
+```
+
+The token will be used instead of the auto-mounted token file.
+
+## Common Operations
+
+### Add a new group (no restart required)
+
+```bash
+oc adm policy add-role-to-group sardeenz-admin-readonly new-team -n sardeenz
+```
+
+Users in `new-team` can now access sardeenz immediately.
+
+### Remove access
+
+```bash
+oc adm policy remove-role-from-user sardeenz-admin alice@company.com -n sardeenz
+oc adm policy remove-role-from-group sardeenz-admin-readonly team-a -n sardeenz
+```
+
+### View current bindings
+
+```bash
+oc get rolebindings -n sardeenz
+oc describe rolebinding sardeenz-admins -n sardeenz
+```
+
+### Test access (impersonation)
+
+```bash
+# Check if a user would have admin access
+oc auth can-i get admin.sardeenz.rh-aiservices-bu.io -n sardeenz --as=alice@company.com
+
+# Check if a group would have read-only access
+oc auth can-i get admin-readonly.sardeenz.rh-aiservices-bu.io -n sardeenz --as=system:serviceaccount:default:default --as-group=team-a
+```
+
+## Role Hierarchy
+
+- **`admin`**: Full access to all sardeenz operations (load/unload models, run benchmarks, change settings)
+- **`admin-readonly`**: Read-only access (view models, view benchmarks, view settings)
+
+A user can have both roles. The `admin` role implies full access, so having both is equivalent to just having `admin`.
+
+## Troubleshooting
+
+### User gets "Access denied" after login
+
+1. Check if the Roles exist:
+   ```bash
+   oc get role sardeenz-admin sardeenz-admin-readonly -n sardeenz
+   ```
+
+2. Check if the user has a RoleBinding:
+   ```bash
+   oc get rolebindings -n sardeenz -o wide
+   ```
+
+3. Test access with impersonation:
+   ```bash
+   oc auth can-i get admin.sardeenz.rh-aiservices-bu.io -n sardeenz --as=user@company.com
+   ```
+
+### LocalSubjectAccessReview fails
+
+Check that sardeenz has the correct `K8S_API_URL` configured and can reach the Kubernetes API server. Also verify that the `sardeenz-auth-reviewer` Role and RoleBinding exist in the namespace.
+
+### Namespace mismatch
+
+Ensure the `NAMESPACE` environment variable in sardeenz matches where the Roles and RoleBindings are created.
+
+## Configuration Reference
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `AUTH_MODE` | `none` | Set to `oauth` to enable OAuth with RBAC |
+| `NAMESPACE` | `sardeenz` | Kubernetes namespace for RBAC checks |
+| `K8S_API_URL` | (required) | Kubernetes API URL for LocalSubjectAccessReview calls |
+| `SERVICE_ACCOUNT_TOKEN` | (auto) | ServiceAccount token for RBAC checks. In K8s, auto-mounted. For dev, set manually. |


### PR DESCRIPTION
Replace group-based role mapping with Kubernetes-native authorization
using LocalSubjectAccessReview API. This allows administrators to manage
sardeenz access through standard OpenShift/Kubernetes tooling.

Changes:
- Add LocalSubjectAccessReview checks for admin and admin-readonly roles
- Support ServiceAccount token from env var or mounted file
- Add namespace configuration for namespace-scoped RBAC checks
- Create marker Roles (sardeenz-admin, sardeenz-admin-readonly)
- Add auth-reviewer Role for ServiceAccount permission checking
- Add comprehensive RBAC setup documentation

This approach uses namespace-scoped Roles instead of ClusterRoles,
requiring no cluster-admin permissions for deployment.

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
