### PR TITLE
feat(models): add sleep mode for GPU memory offloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Sleep Mode**: Put models to sleep to free GPU memory (~90%) while keeping them loaded for quick wake-up
+  - Enable sleep mode per-model at load time via `enable_sleep_mode` parameter
+  - Level 1: Offload weights to CPU RAM (~90% GPU freed)
+  - Level 2: Discard weights and KV cache (for model switching/RLHF)
+  - New API endpoints: `POST /api/models/instances/:id/sleep`, `POST .../wake`, `GET .../sleep-status`
+  - UI: "Enable Sleep Mode" checkbox in Load Model dialog
+  - UI: Sleep/Wake actions in model dropdown menus with moon/sun icons
+  - Purple "sleeping" status badge with moon icon
+  - Proxy returns 503 with clear message for sleeping models
+
 ## [0.3.0] - 2026-01-10
 
 ### Per-GPU KVCache Metrics

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -14,7 +14,7 @@ Fastify backend providing Controller API and Unified Proxy for multi-model LLM m
 
 | Route File                           | Purpose                                                                        |
 | ------------------------------------ | ------------------------------------------------------------------------------ |
-| `src/routes/models.ts`               | Model CRUD: load, unload, list, get, health check, logs                        |
+| `src/routes/models.ts`               | Model CRUD: load, unload, list, get, health check, logs, sleep, wake           |
 | `src/routes/model-configurations.ts` | Configuration CRUD: save, load, list, delete model presets                     |
 | `src/routes/events.ts`               | SSE event streaming endpoint                                                   |
 | `src/routes/health.ts`               | Backend health checks (`/api/health`, `/api/health/ready`, `/api/health/live`) |
@@ -28,6 +28,11 @@ Fastify backend providing Controller API and Unified Proxy for multi-model LLM m
 | `src/routes/settings.ts`             | Application settings (HF token)                                                |
 | `src/routes/auth.ts`                 | Authentication endpoints: info, login, callback, logout, me                    |
 | `src/plugins/inference-auth.ts`      | Inference API key auth (separate from admin JWT)                               |
+
+**Sleep Mode Endpoints** (in `src/routes/models.ts`):
+- `POST /api/models/instances/:instance_id/sleep` - Put model to sleep (frees ~90% GPU memory)
+- `POST /api/models/instances/:instance_id/wake` - Wake sleeping model
+- `GET /api/models/instances/:instance_id/sleep-status` - Check sleep status
 
 ## Stores
 

--- a/apps/backend/src/db/migrations/005-configuration-sleep-mode.sql
+++ b/apps/backend/src/db/migrations/005-configuration-sleep-mode.sql
@@ -1,0 +1,7 @@
+-- Migration 005: Add sleep_mode_enabled to model configuration entries
+-- Tracks whether sleep mode should be enabled when loading models from a configuration
+
+ALTER TABLE model_configuration_entries ADD COLUMN sleep_mode_enabled INTEGER DEFAULT 0;
+
+-- Mark this migration as applied
+INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (5, datetime('now'));

--- a/apps/backend/src/routes/model-configurations.ts
+++ b/apps/backend/src/routes/model-configurations.ts
@@ -392,6 +392,7 @@ export default async function modelConfigurationRoutes(fastify: FastifyInstance)
                   sourceType: entry.sourceType,
                   servedModelName: entry.servedModelName,
                   extraArgs: entry.extraArgs,
+                  enableSleepMode: entry.sleepModeEnabled,
                 })
                 fastify.log.info(
                   { modelPath: entry.modelPath, gpuIds: entry.gpuIds },

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -10,8 +10,15 @@ import {
   ErrorResponseSchema,
   ListInstancesResponseSchema,
   UnloadInstanceResponseSchema,
+  SleepModelRequestSchema,
+  SleepModelResponseSchema,
+  WakeModelRequestSchema,
+  WakeModelResponseSchema,
+  SleepStatusResponseSchema,
   type ModelInstanceDTO,
   type LoadModelRequestType,
+  type SleepModelRequestType,
+  type WakeModelRequestType,
 } from '@sardeenz/types'
 import { getModelManager } from '../services/model-manager.js'
 import { modelStore } from '../stores/model-store.js'
@@ -54,6 +61,9 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
       gpu_ids: instance.gpuIds,
       tensor_parallel_size: instance.tensorParallelSize,
       kvcached_enabled: instance.kvcachedEnabled,
+      sleep_mode_enabled: instance.sleepModeEnabled,
+      sleep_level: instance.sleepLevel,
+      slept_at: instance.sleptAt?.toISOString(),
     }
   }
 
@@ -84,6 +94,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
         tensor_parallel_size,
         source_type,
         served_model_name,
+        enable_sleep_mode,
       } = request.body
 
       const operationId = randomUUID()
@@ -112,6 +123,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           tensorParallelSize: tensor_parallel_size,
           sourceType: source_type,
           servedModelName: served_model_name,
+          enableSleepMode: enable_sleep_mode,
         })
 
         // Operation stays InProgress - will be updated when model finishes loading
@@ -517,6 +529,171 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
         instance_id,
         logs,
         line_count: lineCount,
+      }
+    }
+  )
+
+  /**
+   * POST /api/models/instances/:instance_id/sleep - Put model to sleep
+   */
+  fastify.post<{
+    Params: { instance_id: string }
+    Body: SleepModelRequestType
+  }>(
+    '/api/models/instances/:instance_id/sleep',
+    {
+      schema: {
+        tags: ['models'],
+        summary: 'Put model instance to sleep',
+        params: Type.Object({ instance_id: Type.String({ format: 'uuid' }) }),
+        body: SleepModelRequestSchema,
+        response: {
+          200: SleepModelResponseSchema,
+          400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+          409: ErrorResponseSchema,
+        },
+      },
+      onRequest: fastify.requireRole('admin'),
+    },
+    async (request, reply) => {
+      const { instance_id } = request.params
+      const { level = 1 } = request.body ?? {}
+
+      try {
+        await modelManager.sleepModel(instance_id, level)
+
+        const instance = modelStore.get(instance_id)
+        if (!instance) {
+          return reply.status(404).send({
+            error: 'Not Found',
+            message: `Model instance ${instance_id} not found`,
+          })
+        }
+
+        return reply.send({
+          status: 'success' as const,
+          instance_id,
+          model_path: instance.modelPath,
+          sleep_level: level,
+          slept_at: instance.sleptAt?.toISOString() ?? new Date().toISOString(),
+        })
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return reply.status(404).send({
+            error: 'Not Found',
+            message: err.message,
+          })
+        }
+        if (err instanceof AppError) {
+          const statusCode = err.message.includes('not loaded with sleep mode') ? 400 : 409
+          return reply.status(statusCode).send({
+            error: statusCode === 400 ? 'Bad Request' : 'Conflict',
+            message: err.message,
+          })
+        }
+        throw err
+      }
+    }
+  )
+
+  /**
+   * POST /api/models/instances/:instance_id/wake - Wake sleeping model
+   */
+  fastify.post<{
+    Params: { instance_id: string }
+    Body: WakeModelRequestType
+  }>(
+    '/api/models/instances/:instance_id/wake',
+    {
+      schema: {
+        tags: ['models'],
+        summary: 'Wake a sleeping model instance',
+        params: Type.Object({ instance_id: Type.String({ format: 'uuid' }) }),
+        body: WakeModelRequestSchema,
+        response: {
+          200: WakeModelResponseSchema,
+          404: ErrorResponseSchema,
+          409: ErrorResponseSchema,
+        },
+      },
+      onRequest: fastify.requireRole('admin'),
+    },
+    async (request, reply) => {
+      const { instance_id } = request.params
+      const { tags } = request.body ?? {}
+
+      try {
+        await modelManager.wakeModel(instance_id, tags)
+
+        const instance = modelStore.get(instance_id)
+        if (!instance) {
+          return reply.status(404).send({
+            error: 'Not Found',
+            message: `Model instance ${instance_id} not found`,
+          })
+        }
+
+        return reply.send({
+          status: 'success' as const,
+          instance_id,
+          model_path: instance.modelPath,
+          woke_at: new Date().toISOString(),
+        })
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return reply.status(404).send({
+            error: 'Not Found',
+            message: err.message,
+          })
+        }
+        if (err instanceof AppError) {
+          return reply.status(409).send({
+            error: 'Conflict',
+            message: err.message,
+          })
+        }
+        throw err
+      }
+    }
+  )
+
+  /**
+   * GET /api/models/instances/:instance_id/sleep-status - Check sleep status
+   */
+  fastify.get<{ Params: { instance_id: string } }>(
+    '/api/models/instances/:instance_id/sleep-status',
+    {
+      schema: {
+        tags: ['models'],
+        summary: 'Check if model instance is sleeping',
+        params: Type.Object({ instance_id: Type.String({ format: 'uuid' }) }),
+        response: {
+          200: SleepStatusResponseSchema,
+          404: ErrorResponseSchema,
+        },
+      },
+      onRequest: fastify.requireRole('admin-readonly'),
+    },
+    async (request, reply) => {
+      const { instance_id } = request.params
+
+      try {
+        const sleepStatus = await modelManager.isSleeping(instance_id)
+
+        return reply.send({
+          instance_id,
+          is_sleeping: sleepStatus.isSleeping,
+          sleep_level: sleepStatus.level,
+        })
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return reply.status(404).send({
+            error: 'Not Found',
+            message: err.message,
+          })
+        }
+        throw err
       }
     }
   )

--- a/apps/backend/src/services/memory-monitor.ts
+++ b/apps/backend/src/services/memory-monitor.ts
@@ -157,16 +157,18 @@ export class MemoryMonitor {
         pidToGpuMemory.set(proc.pid, { gpuIndex: proc.gpu, memoryMB: proc.gpuMemoryMB })
       }
 
-      // Get all running model instances
+      // Get all running and sleeping model instances (sleeping models still consume some GPU memory)
       const allInstances = modelStore.getAll()
-      const runningInstances = allInstances.filter((i) => i.status === 'running')
+      const activeInstances = allInstances.filter(
+        (i) => i.status === 'running' || i.status === 'sleeping'
+      )
 
       // Group models by GPU with display name management
       const modelsByGpu = new Map<number, ModelGpuMemory[]>()
       const displayNameCounts = new Map<string, number>()
 
-      for (let index = 0; index < runningInstances.length; index++) {
-        const instance = runningInstances[index]
+      for (let index = 0; index < activeInstances.length; index++) {
+        const instance = activeInstances[index]
         const gpuPid = instance.engineCorePid ?? instance.processId
         const baseName = getDisplayName(instance.modelPath)
         const count = (displayNameCounts.get(baseName) ?? 0) + 1
@@ -200,6 +202,7 @@ export class MemoryMonitor {
               display_name: `${displayName} (TP)`,
               gpu_memory_gb: perGpuMemoryGb,
               color: getModelColor(instance.id, index),
+              is_sleeping: instance.status === 'sleeping',
             })
           }
         } else {
@@ -217,13 +220,14 @@ export class MemoryMonitor {
             display_name: displayName,
             gpu_memory_gb: memoryGb,
             color: getModelColor(instance.id, index),
+            is_sleeping: instance.status === 'sleeping',
           })
         }
       }
 
       // Sum model baselines per GPU (from memoryBaselineByGpu captured at model load)
       const baselinesByGpu = new Map<number, number>() // gpuId -> total baseline GB
-      for (const instance of runningInstances) {
+      for (const instance of activeInstances) {
         for (const [gpuIdStr, baselineGb] of Object.entries(instance.memoryBaselineByGpu ?? {})) {
           const gpuId = parseInt(gpuIdStr)
           baselinesByGpu.set(gpuId, (baselinesByGpu.get(gpuId) ?? 0) + baselineGb)

--- a/apps/backend/src/services/model-manager.ts
+++ b/apps/backend/src/services/model-manager.ts
@@ -23,6 +23,7 @@ export interface LaunchModelOptions {
   tensorParallelSize?: number // For large models spanning multiple GPUs (default: 1)
   sourceType?: 'huggingface' | 'local' // Model source type (default: 'huggingface')
   servedModelName?: string // Name for vLLM --served-model-name (default: modelPath)
+  enableSleepMode?: boolean // Enable vLLM sleep mode for GPU memory offloading
 }
 
 /** Arguments that are managed by the system and should be filtered out from user input */
@@ -94,6 +95,7 @@ export class ModelManager extends EventEmitter {
       gpuIds,
       tensorParallelSize = 1,
       servedModelName,
+      enableSleepMode = false,
     } = options
 
     // Use explicit servedModelName if provided, otherwise fall back to modelPath
@@ -145,6 +147,7 @@ export class ModelManager extends EventEmitter {
       tensorParallelSize,
       kvcachedEnabled: enableKvcached,
       memoryBaselineByGpu: {}, // Will be populated when model becomes ready
+      sleepModeEnabled: enableSleepMode,
     }
 
     try {
@@ -181,6 +184,11 @@ export class ModelManager extends EventEmitter {
         baseArgs.push('--no-enable-prefix-caching') // Required for kvcached
       }
 
+      // Add sleep mode flag if enabled
+      if (enableSleepMode) {
+        baseArgs.push('--enable-sleep-mode')
+      }
+
       // Append sanitized user-provided extra arguments (may include overrides)
       const allArgs = [...baseArgs, ...sanitizedExtraArgs]
 
@@ -204,6 +212,7 @@ export class ModelManager extends EventEmitter {
           KVCACHED_AUTOPATCH: config.kvcachedAutopatch && enableKvcached ? '1' : '0',
           ...(kvcachedIpcName ? { KVCACHED_IPC_NAME: kvcachedIpcName } : {}), // Per-GPU IPC segment
           ...(hfToken ? { HF_TOKEN: hfToken } : {}),
+          ...(enableSleepMode ? { VLLM_SERVER_DEV_MODE: '1' } : {}), // Required for sleep mode
         },
         stdio: ['ignore', 'pipe', 'pipe'],
       })
@@ -679,6 +688,177 @@ export class ModelManager extends EventEmitter {
    */
   listModels(): ModelInstance[] {
     return modelStore.getAll()
+  }
+
+  /**
+   * Put a model instance to sleep.
+   * Offloads model weights to CPU RAM and frees GPU memory.
+   * Requires model to have been loaded with enableSleepMode=true.
+   */
+  async sleepModel(instanceId: string, level: 1 | 2 = 1): Promise<void> {
+    const instance = modelStore.get(instanceId)
+    if (!instance) {
+      throw new NotFoundError(`Model instance ${instanceId} not found`)
+    }
+
+    if (!instance.sleepModeEnabled) {
+      throw new InternalError('Model was not loaded with sleep mode enabled')
+    }
+
+    if (instance.status !== 'running') {
+      throw new InternalError(`Cannot sleep model: current status is ${instance.status}`)
+    }
+
+    try {
+      // Call vLLM sleep endpoint
+      const response = await fetch(`http://localhost:${instance.port}/sleep?level=${level}`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(30000),
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => response.statusText)
+        throw new InternalError(`Failed to put model to sleep: ${errorText}`)
+      }
+
+      // Update instance state
+      const previousStatus = instance.status
+      instance.status = 'sleeping' as ModelStatus
+      instance.sleepLevel = level
+      instance.sleptAt = new Date()
+      modelStore.set(instance)
+
+      // Emit status event
+      eventBus.emitEvent(
+        eventBus.createStatusEvent(
+          instanceId,
+          previousStatus,
+          'sleeping' as ModelStatus,
+          `Model sleeping (level ${level})`
+        )
+      )
+
+      this.logger.info({ instanceId, modelPath: instance.modelPath, level }, 'Model put to sleep')
+    } catch (err) {
+      if (err instanceof NotFoundError || err instanceof InternalError) {
+        throw err
+      }
+      throw new InternalError(`Failed to put model to sleep: ${err instanceof Error ? err.message : 'Unknown error'}`)
+    }
+  }
+
+  /**
+   * Wake a sleeping model instance.
+   * Reloads model weights from CPU RAM back to GPU.
+   */
+  async wakeModel(instanceId: string, tags?: 'weights' | 'kv_cache'): Promise<void> {
+    const instance = modelStore.get(instanceId)
+    if (!instance) {
+      throw new NotFoundError(`Model instance ${instanceId} not found`)
+    }
+
+    if (instance.status !== 'sleeping') {
+      throw new InternalError('Model is not sleeping')
+    }
+
+    try {
+      // Build request body for optional tags
+      const requestBody = tags ? JSON.stringify({ tags: [tags] }) : undefined
+      const headers: Record<string, string> = {}
+      if (requestBody) {
+        headers['Content-Type'] = 'application/json'
+      }
+
+      // Call vLLM wake_up endpoint
+      const response = await fetch(`http://localhost:${instance.port}/wake_up`, {
+        method: 'POST',
+        headers,
+        body: requestBody,
+        signal: AbortSignal.timeout(60000), // Wake may take longer
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => response.statusText)
+        throw new InternalError(`Failed to wake model: ${errorText}`)
+      }
+
+      // Poll for ready state (model may need time to reload weights)
+      const pollStart = Date.now()
+      const pollTimeout = 120000 // 2 minutes max
+      const pollInterval = 2000
+
+      while (Date.now() - pollStart < pollTimeout) {
+        try {
+          const healthResponse = await fetch(`http://localhost:${instance.port}/health`, {
+            signal: AbortSignal.timeout(2000),
+          })
+
+          if (healthResponse.ok) {
+            break // Model is ready
+          }
+        } catch {
+          // Continue polling
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollInterval))
+      }
+
+      // Update instance state
+      const previousStatus = instance.status
+      instance.status = 'running' as ModelStatus
+      instance.sleepLevel = undefined
+      instance.sleptAt = undefined
+      modelStore.set(instance)
+
+      // Emit status event
+      eventBus.emitEvent(
+        eventBus.createStatusEvent(
+          instanceId,
+          previousStatus,
+          'running' as ModelStatus,
+          'Model woken up and ready'
+        )
+      )
+
+      this.logger.info({ instanceId, modelPath: instance.modelPath }, 'Model woken up')
+    } catch (err) {
+      if (err instanceof NotFoundError || err instanceof InternalError) {
+        throw err
+      }
+      throw new InternalError(`Failed to wake model: ${err instanceof Error ? err.message : 'Unknown error'}`)
+    }
+  }
+
+  /**
+   * Check if a model instance is sleeping.
+   */
+  async isSleeping(instanceId: string): Promise<{ isSleeping: boolean; level?: 1 | 2 }> {
+    const instance = modelStore.get(instanceId)
+    if (!instance) {
+      throw new NotFoundError(`Model instance ${instanceId} not found`)
+    }
+
+    // If status is sleeping in our store, return that
+    if (instance.status === 'sleeping') {
+      return { isSleeping: true, level: instance.sleepLevel }
+    }
+
+    // Optionally verify with vLLM endpoint if sleep mode is enabled
+    if (instance.sleepModeEnabled && instance.status === 'running') {
+      try {
+        const response = await fetch(`http://localhost:${instance.port}/is_sleeping`, {
+          signal: AbortSignal.timeout(5000),
+        })
+
+        if (response.ok) {
+          const data = await response.json() as { is_sleeping: boolean }
+          return { isSleeping: data.is_sleeping, level: data.is_sleeping ? instance.sleepLevel : undefined }
+        }
+      } catch {
+        // If endpoint fails, rely on stored state
+      }
+    }
+
+    return { isSleeping: false }
   }
 
   /**

--- a/apps/backend/src/services/proxy-router.ts
+++ b/apps/backend/src/services/proxy-router.ts
@@ -111,7 +111,15 @@ export class ProxyRouter {
         )
       }
 
-      // Instances exist but none are running
+      // Check if there are sleeping instances
+      const sleepingInstances = allInstances.filter((i) => i.status === 'sleeping')
+      if (sleepingInstances.length > 0) {
+        throw new ServiceUnavailableError(
+          `Model ${modelPath} is sleeping. Wake it up to serve requests.`
+        )
+      }
+
+      // Instances exist but none are running (and not sleeping)
       const statuses = allInstances.map((i) => `${i.id.slice(0, 8)}:${i.status}`).join(', ')
       throw new ServiceUnavailableError(
         `Model ${modelPath} has no running instances. Instance states: ${statuses}`

--- a/apps/backend/src/stores/model-configuration-store.ts
+++ b/apps/backend/src/stores/model-configuration-store.ts
@@ -37,6 +37,7 @@ interface EntryRow {
   gpu_ids: string | null // JSON
   tensor_parallel_size: number
   load_order: number
+  sleep_mode_enabled: number // SQLite stores booleans as 0/1
 }
 
 // Convert row to domain object
@@ -63,6 +64,7 @@ function rowToEntry(row: EntryRow): ModelConfigurationEntry {
     gpuIds: row.gpu_ids ? JSON.parse(row.gpu_ids) : undefined,
     tensorParallelSize: row.tensor_parallel_size,
     loadOrder: row.load_order,
+    sleepModeEnabled: row.sleep_mode_enabled === 1,
   }
 }
 
@@ -83,8 +85,10 @@ class ModelConfigurationStore {
     const id = randomUUID()
     const now = new Date().toISOString()
 
-    // Filter to only running models
-    const runningInstances = instances.filter((i) => i.status === 'running')
+    // Filter to running and sleeping models (both are valid active configurations)
+    const activeInstances = instances.filter(
+      (i) => i.status === 'running' || i.status === 'sleeping'
+    )
 
     const insertConfig = this.db.prepare(`
       INSERT INTO model_configurations (id, name, description, model_count, created_at)
@@ -93,14 +97,14 @@ class ModelConfigurationStore {
 
     const insertEntry = this.db.prepare(`
       INSERT INTO model_configuration_entries
-      (id, config_id, model_path, served_model_name, max_tokens, source_type, extra_args, gpu_ids, tensor_parallel_size, load_order)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (id, config_id, model_path, served_model_name, max_tokens, source_type, extra_args, gpu_ids, tensor_parallel_size, load_order, sleep_mode_enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `)
 
     const transaction = this.db.transaction(() => {
-      insertConfig.run(id, input.name, input.description ?? null, runningInstances.length, now)
+      insertConfig.run(id, input.name, input.description ?? null, activeInstances.length, now)
 
-      runningInstances.forEach((instance, index) => {
+      activeInstances.forEach((instance, index) => {
         // Determine if served_model_name differs from model path
         const servedModelName =
           instance.modelName !== instance.modelPath ? instance.modelName : null
@@ -115,7 +119,8 @@ class ModelConfigurationStore {
           null, // Extra args not captured from running instance
           instance.gpuIds.length > 0 ? JSON.stringify(instance.gpuIds) : null,
           instance.tensorParallelSize,
-          index
+          index,
+          instance.sleepModeEnabled ? 1 : 0
         )
       })
     })
@@ -126,7 +131,7 @@ class ModelConfigurationStore {
       id,
       name: input.name,
       description: input.description,
-      modelCount: runningInstances.length,
+      modelCount: activeInstances.length,
       createdAt: now,
     }
   }

--- a/apps/frontend/src/components/GpuGroupSection.tsx
+++ b/apps/frontend/src/components/GpuGroupSection.tsx
@@ -9,7 +9,11 @@ interface GpuGroupSectionProps {
   isExpanded: boolean
   onToggle: (gpuKey: string) => void
   onUnload: (instanceId: string, modelPath: string, isFailed: boolean) => void
+  onSleep?: (instanceId: string) => void
+  onWake?: (instanceId: string) => void
   unloadingInstanceId: string | null
+  sleepingInstanceId?: string | null
+  wakingInstanceId?: string | null
   expandedCards: Set<string>
   onCardToggle: (instanceId: string) => void
 }
@@ -25,7 +29,11 @@ export function GpuGroupSection({
   isExpanded,
   onToggle,
   onUnload,
+  onSleep,
+  onWake,
   unloadingInstanceId,
+  sleepingInstanceId,
+  wakingInstanceId,
   expandedCards,
   onCardToggle,
 }: GpuGroupSectionProps) {
@@ -68,7 +76,7 @@ export function GpuGroupSection({
       )}
       {statusCounts.sleeping > 0 && (
         <FlexItem>
-          <Label isCompact color="orange">
+          <Label isCompact color="purple">
             {statusCounts.sleeping} sleeping
           </Label>
         </FlexItem>
@@ -105,7 +113,11 @@ export function GpuGroupSection({
               id={`model-card-${model.id}`}
               model={model}
               onUnload={onUnload}
+              onSleep={onSleep}
+              onWake={onWake}
               isUnloading={unloadingInstanceId === model.id}
+              isSleeping={sleepingInstanceId === model.id}
+              isWaking={wakingInstanceId === model.id}
               isExpanded={expandedCards.has(model.id)}
               onToggle={() => onCardToggle(model.id)}
             />

--- a/apps/frontend/src/components/GpuMemoryPanel.tsx
+++ b/apps/frontend/src/components/GpuMemoryPanel.tsx
@@ -15,6 +15,7 @@ import {
   Tab,
   TabTitleText,
 } from '@patternfly/react-core'
+import { MoonIcon } from '@patternfly/react-icons'
 import { ResponsiveBar } from '@nivo/bar'
 import type { MultiGpuMemoryUsageResponse, PerGpuMetrics } from '@sardeenz/types'
 import { apiClient } from '../services/api'
@@ -37,6 +38,19 @@ const KVCACHE_COLORS = {
 
 const FREE_COLOR = '#D2D2D2' // Light gray for free space
 
+// Pattern definition for sleeping models (diagonal hatching)
+const SLEEPING_PATTERN_DEFS = [
+  {
+    id: 'sleeping-pattern',
+    type: 'patternLines' as const,
+    background: 'inherit',
+    color: 'rgba(0, 0, 0, 0.3)',
+    rotation: -45,
+    lineWidth: 3,
+    spacing: 8,
+  },
+]
+
 // Nivo tooltip theme - detects PatternFly dark mode for proper styling
 const getTooltipTheme = () => {
   const isDark = document.documentElement.classList.contains('pf-v6-theme-dark')
@@ -57,6 +71,7 @@ const getTooltipTheme = () => {
 interface GpuMemoryPanelProps {
   defaultRefreshInterval?: number | null
   onModelClick?: (instanceId: string) => void
+  refreshTrigger?: number
 }
 
 /**
@@ -66,7 +81,11 @@ interface GpuMemoryPanelProps {
  * - KVCache: shared pool (Prealloc / Used / Free)
  * - GPU: per-model breakdown with colors
  */
-export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: GpuMemoryPanelProps) {
+export function GpuMemoryPanel({
+  defaultRefreshInterval = 5000,
+  onModelClick,
+  refreshTrigger,
+}: GpuMemoryPanelProps) {
   const [memoryData, setMemoryData] = useState<MultiGpuMemoryUsageResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -94,7 +113,7 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
 
     const interval = setInterval(fetchMemoryUsage, refreshInterval)
     return () => clearInterval(interval)
-  }, [fetchMemoryUsage, refreshInterval])
+  }, [fetchMemoryUsage, refreshInterval, refreshTrigger])
 
   // Get the currently selected GPU data
   const selectedGpu: PerGpuMetrics | null = useMemo(() => {
@@ -122,7 +141,13 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
 
   // Build GPU bar data with per-model breakdown for selected GPU
   const gpuData = useMemo(() => {
-    if (!selectedGpu) return { data: [], keys: [], colors: {} as Record<string, string> }
+    if (!selectedGpu)
+      return {
+        data: [],
+        keys: [],
+        colors: {} as Record<string, string>,
+        fill: [] as Array<{ match: { id: string }; id: string }>,
+      }
 
     const { models } = selectedGpu
     const modelsMemory = models.reduce((sum, m) => sum + m.gpu_memory_gb, 0)
@@ -133,6 +158,7 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
     const dataObj: Record<string, number | string> = { id: 'GPU' }
     const keys: string[] = []
     const colors: Record<string, string> = {}
+    const fill: Array<{ match: { id: string }; id: string }> = []
 
     // Add each model
     models.forEach((model) => {
@@ -140,6 +166,11 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
       dataObj[key] = Number(model.gpu_memory_gb.toFixed(2))
       keys.push(key)
       colors[key] = model.color
+
+      // Apply hatching pattern to sleeping models
+      if (model.is_sleeping) {
+        fill.push({ match: { id: key }, id: 'sleeping-pattern' })
+      }
     })
 
     // Add Other (system processes, etc.)
@@ -154,7 +185,7 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
     keys.push('Free')
     colors['Free'] = FREE_COLOR
 
-    return { data: [dataObj], keys, colors }
+    return { data: [dataObj], keys, colors, fill }
   }, [selectedGpu])
 
   const formatGb = (value: number) => `${value.toFixed(2)} GB`
@@ -257,8 +288,8 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
               {memoryData && memoryData.gpus.length === 1 && selectedGpu && (
                 <>{selectedGpu.name} — </>
               )}
-              {formatGb(selectedGpu?.used_gb ?? 0)} / {formatGb(selectedGpu?.total_gb ?? 0)}{' '}
-              ({selectedGpu?.utilization_percent.toFixed(0) ?? 0}% utilized)
+              VRAM: {formatGb(selectedGpu?.used_gb ?? 0)} / {formatGb(selectedGpu?.total_gb ?? 0)}{' — '}
+              GPU Load: {selectedGpu?.utilization_percent.toFixed(0) ?? 0}%
             </Content>
             <div style={{ height: '40px', marginTop: 'var(--pf-t--global--spacer--xs)' }}>
               <ResponsiveBar
@@ -269,6 +300,8 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
                 margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
                 padding={0}
                 colors={(bar) => gpuData.colors[bar.id as string] || '#ccc'}
+                defs={SLEEPING_PATTERN_DEFS}
+                fill={gpuData.fill}
                 borderRadius={4}
                 enableLabel={false}
                 enableGridY={false}
@@ -322,9 +355,20 @@ export function GpuMemoryPanel({ defaultRefreshInterval = 5000, onModelClick }: 
                     style={{
                       cursor: onModelClick ? 'pointer' : 'default',
                       fontSize: 'var(--pf-t--global--font--size--sm)',
+                      opacity: model.is_sleeping ? 0.7 : 1,
                     }}
                   >
-                    <span style={{ color: model.color }}>●</span> {model.display_name} ({formatGb(model.gpu_memory_gb)})
+                    <span style={{ color: model.color }}>●</span> {model.display_name}
+                    {model.is_sleeping && (
+                      <MoonIcon
+                        style={{
+                          marginLeft: '4px',
+                          fontSize: 'var(--pf-t--global--font--size--xs)',
+                          color: 'var(--pf-t--global--text--color--subtle)',
+                        }}
+                      />
+                    )}{' '}
+                    ({formatGb(model.gpu_memory_gb)})
                   </span>
                 </FlexItem>
               ))}

--- a/apps/frontend/src/components/LoadModelDialog.tsx
+++ b/apps/frontend/src/components/LoadModelDialog.tsx
@@ -95,6 +95,9 @@ export function LoadModelDialog({
   const [isCheckingMemory, setIsCheckingMemory] = useState(false)
   const memoryCheckTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Sleep mode state (enabled by default)
+  const [enableSleepMode, setEnableSleepMode] = useState(true)
+
   // GPU info state (needed for memory check)
   const [gpuName, setGpuName] = useState<string | null>(null)
 
@@ -278,6 +281,11 @@ export function LoadModelDialog({
         }
       }
 
+      // Include sleep mode option
+      if (enableSleepMode) {
+        request.enable_sleep_mode = true
+      }
+
       const result = await onLoad(request)
 
       // Start listening for events from this instance
@@ -312,6 +320,7 @@ export function LoadModelDialog({
     setLocalModels([])
     setCurrentSubpath('')
     setLocalModelsBasePath('')
+    setEnableSleepMode(false)
     onClose()
   }, [onClose])
 
@@ -718,6 +727,16 @@ export function LoadModelDialog({
                     </HelperText>
                   </FormHelperText>
                 ) : null}
+              </FormGroup>
+
+              <FormGroup fieldId="enable-sleep-mode">
+                <Checkbox
+                  id="enable-sleep-mode"
+                  label="Enable Sleep Mode"
+                  description="Allows model to be put to sleep to free GPU memory (~90%) while keeping it loaded for quick wake-up"
+                  isChecked={enableSleepMode}
+                  onChange={(_event, checked) => setEnableSleepMode(checked)}
+                />
               </FormGroup>
 
               <FormGroup label="Additional vLLM Arguments" fieldId="extra-args">

--- a/apps/frontend/src/components/ModelCardCompact.tsx
+++ b/apps/frontend/src/components/ModelCardCompact.tsx
@@ -29,7 +29,7 @@ import {
   Tooltip,
   ClipboardCopyButton,
 } from '@patternfly/react-core'
-import { EllipsisVIcon, FileIcon, TrashIcon, OutlinedClockIcon } from '@patternfly/react-icons'
+import { EllipsisVIcon, FileIcon, TrashIcon, OutlinedClockIcon, MoonIcon, SunIcon } from '@patternfly/react-icons'
 import type { ModelInstanceDTO, ModelStatus } from '@sardeenz/types'
 import { ModelStatusBadge } from './ModelStatusBadge'
 import { ViewLogsDialog } from './ViewLogsDialog'
@@ -40,7 +40,11 @@ import { useAuth } from '../contexts/AuthContext'
 interface ModelCardCompactProps {
   model: ModelInstanceDTO
   onUnload: (instanceId: string, modelPath: string, isFailed: boolean) => void
+  onSleep?: (instanceId: string) => void
+  onWake?: (instanceId: string) => void
   isUnloading?: boolean
+  isSleeping?: boolean
+  isWaking?: boolean
   isExpanded: boolean
   onToggle: () => void
   id?: string
@@ -63,7 +67,11 @@ const STATUS_BORDER_COLORS: Record<ModelStatus, string> = {
 export function ModelCardCompact({
   model,
   onUnload,
+  onSleep,
+  onWake,
   isUnloading = false,
+  isSleeping = false,
+  isWaking = false,
   isExpanded,
   onToggle,
   id,
@@ -194,7 +202,7 @@ export function ModelCardCompact({
                 )}
               >
               <DropdownList>
-                {(model.status === 'running' || model.status === 'failed') && (
+                {(model.status === 'running' || model.status === 'failed' || model.status === 'sleeping') && (
                   <DropdownItem
                     key="logs"
                     icon={<FileIcon />}
@@ -211,7 +219,27 @@ export function ModelCardCompact({
                     Memory details
                   </DropdownItem>
                 )}
-                {(model.status === 'running' || model.status === 'failed') && <Divider key="divider" />}
+                {model.status === 'running' && model.sleep_mode_enabled && onSleep && (
+                  <DropdownItem
+                    key="sleep"
+                    icon={<MoonIcon />}
+                    onClick={() => onSleep(model.id)}
+                    isDisabled={isSleeping || !canWrite}
+                  >
+                    {isSleeping ? 'Sleeping...' : 'Put to Sleep'}
+                  </DropdownItem>
+                )}
+                {model.status === 'sleeping' && onWake && (
+                  <DropdownItem
+                    key="wake"
+                    icon={<SunIcon />}
+                    onClick={() => onWake(model.id)}
+                    isDisabled={isWaking || !canWrite}
+                  >
+                    {isWaking ? 'Waking...' : 'Wake Up'}
+                  </DropdownItem>
+                )}
+                {(model.status === 'running' || model.status === 'failed' || model.status === 'sleeping') && <Divider key="divider" />}
                 <DropdownItem
                   key="unload"
                   icon={<TrashIcon />}

--- a/apps/frontend/src/components/ModelStatusBadge.tsx
+++ b/apps/frontend/src/components/ModelStatusBadge.tsx
@@ -1,4 +1,5 @@
 import { Label, Spinner } from '@patternfly/react-core'
+import { MoonIcon } from '@patternfly/react-icons'
 import type { ModelStatus } from '@sardeenz/types'
 
 interface ModelStatusBadgeProps {
@@ -33,9 +34,16 @@ export function ModelStatusBadge({ status, isCompact = false }: ModelStatusBadge
   }
 
   const isLoading = status === 'starting' || status === 'stopping'
+  const isSleeping = status === 'sleeping'
+
+  const getIcon = () => {
+    if (isLoading) return <Spinner size="sm" />
+    if (isSleeping) return <MoonIcon />
+    return undefined
+  }
 
   return (
-    <Label color={getColor()} isCompact={isCompact} icon={isLoading ? <Spinner size="sm" /> : undefined}>
+    <Label color={getColor()} isCompact={isCompact} icon={getIcon()}>
       {getLabel()}
     </Label>
   )

--- a/apps/frontend/src/components/ModelTable.tsx
+++ b/apps/frontend/src/components/ModelTable.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   ClipboardCopyButton,
 } from '@patternfly/react-core'
-import { TrashIcon, FileIcon, OutlinedClockIcon } from '@patternfly/react-icons'
+import { TrashIcon, FileIcon, OutlinedClockIcon, MoonIcon, SunIcon } from '@patternfly/react-icons'
 import type { ModelInstanceDTO } from '@sardeenz/types'
 import { ModelStatusBadge } from './ModelStatusBadge'
 import { ViewLogsDialog } from './ViewLogsDialog'
@@ -28,7 +28,11 @@ interface ModelTableProps {
   sortDirection: SortDirection
   onSort: (field: SortField) => void
   onUnload: (instanceId: string, modelPath: string, isFailed: boolean) => void
+  onSleep?: (instanceId: string) => void
+  onWake?: (instanceId: string) => void
   unloadingInstanceId: string | null
+  sleepingInstanceId?: string | null
+  wakingInstanceId?: string | null
 }
 
 // Column definitions for sorting
@@ -43,7 +47,11 @@ export function ModelTable({
   sortDirection,
   onSort,
   onUnload,
+  onSleep,
+  onWake,
   unloadingInstanceId,
+  sleepingInstanceId,
+  wakingInstanceId,
 }: ModelTableProps) {
   const { canWrite } = useAuth()
 
@@ -194,7 +202,7 @@ export function ModelTable({
                 </Td>
                 <Td dataLabel="Actions">
                   <Flex gap={{ default: 'gapXs' }}>
-                    {(model.status === 'running' || model.status === 'failed') && (
+                    {(model.status === 'running' || model.status === 'failed' || model.status === 'sleeping') && (
                       <FlexItem>
                         <Tooltip content="View logs">
                           <Button
@@ -202,6 +210,34 @@ export function ModelTable({
                             icon={<FileIcon />}
                             aria-label={`View logs for ${model.model_path}`}
                             onClick={() => setLogsModalOpen(model.id)}
+                          />
+                        </Tooltip>
+                      </FlexItem>
+                    )}
+                    {model.status === 'running' && model.sleep_mode_enabled && onSleep && (
+                      <FlexItem>
+                        <Tooltip content={!canWrite ? 'You do not have permission' : 'Put to Sleep'}>
+                          <Button
+                            variant="plain"
+                            icon={<MoonIcon />}
+                            aria-label={`Put ${model.model_path} to sleep`}
+                            onClick={() => onSleep(model.id)}
+                            isDisabled={sleepingInstanceId === model.id || !canWrite}
+                            isLoading={sleepingInstanceId === model.id}
+                          />
+                        </Tooltip>
+                      </FlexItem>
+                    )}
+                    {model.status === 'sleeping' && onWake && (
+                      <FlexItem>
+                        <Tooltip content={!canWrite ? 'You do not have permission' : 'Wake Up'}>
+                          <Button
+                            variant="plain"
+                            icon={<SunIcon />}
+                            aria-label={`Wake up ${model.model_path}`}
+                            onClick={() => onWake(model.id)}
+                            isDisabled={wakingInstanceId === model.id || !canWrite}
+                            isLoading={wakingInstanceId === model.id}
                           />
                         </Tooltip>
                       </FlexItem>

--- a/apps/frontend/src/pages/ModelManagement.tsx
+++ b/apps/frontend/src/pages/ModelManagement.tsx
@@ -50,10 +50,13 @@ function ModelManagement() {
   const [loading, setLoading] = useState(true)
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false)
   const [unloadingInstanceId, setUnloadingInstanceId] = useState<string | null>(null)
+  const [sleepingInstanceId, setSleepingInstanceId] = useState<string | null>(null)
+  const [wakingInstanceId, setWakingInstanceId] = useState<string | null>(null)
   const [isSaveConfigOpen, setIsSaveConfigOpen] = useState(false)
   const [isLoadConfigOpen, setIsLoadConfigOpen] = useState(false)
   const [isUnloadAllModalOpen, setIsUnloadAllModalOpen] = useState(false)
   const [isUnloadingAll, setIsUnloadingAll] = useState(false)
+  const [gpuRefreshTrigger, setGpuRefreshTrigger] = useState(0)
 
   // View mode state
   const [viewMode, setViewMode] = useState<ViewMode>('card')
@@ -74,6 +77,11 @@ function ModelManagement() {
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set())
 
   const { addNotification } = useNotifications()
+
+  // Trigger GPU memory panel refresh
+  const triggerGpuRefresh = useCallback(() => {
+    setGpuRefreshTrigger((prev) => prev + 1)
+  }, [])
 
   // Count running models for configuration save
   const runningModelCount = useMemo(
@@ -201,6 +209,7 @@ function ModelManagement() {
 
   const handleLoadSuccess = () => {
     fetchModels()
+    triggerGpuRefresh()
     addNotification({
       title: 'Model loaded',
       description: 'Model is now ready for inference',
@@ -220,6 +229,7 @@ function ModelManagement() {
         variant: 'success',
       })
       await fetchModels()
+      triggerGpuRefresh()
     } catch (err) {
       addNotification({
         title: isFailed ? 'Failed to remove model' : 'Failed to unload model',
@@ -228,6 +238,56 @@ function ModelManagement() {
       })
     } finally {
       setUnloadingInstanceId(null)
+    }
+  }
+
+  const handleSleepModel = async (instanceId: string) => {
+    const model = models.find((m) => m.id === instanceId)
+    if (!model) return
+
+    setSleepingInstanceId(instanceId)
+    try {
+      await apiClient.sleepModel(instanceId)
+      addNotification({
+        title: 'Model sleeping',
+        description: `${model.model_path} has been put to sleep`,
+        variant: 'success',
+      })
+      await fetchModels()
+      triggerGpuRefresh()
+    } catch (err) {
+      addNotification({
+        title: 'Failed to sleep model',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'danger',
+      })
+    } finally {
+      setSleepingInstanceId(null)
+    }
+  }
+
+  const handleWakeModel = async (instanceId: string) => {
+    const model = models.find((m) => m.id === instanceId)
+    if (!model) return
+
+    setWakingInstanceId(instanceId)
+    try {
+      await apiClient.wakeModel(instanceId)
+      addNotification({
+        title: 'Model woken up',
+        description: `${model.model_path} is now ready for inference`,
+        variant: 'success',
+      })
+      await fetchModels()
+      triggerGpuRefresh()
+    } catch (err) {
+      addNotification({
+        title: 'Failed to wake model',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'danger',
+      })
+    } finally {
+      setWakingInstanceId(null)
     }
   }
 
@@ -245,7 +305,10 @@ function ModelManagement() {
       description: message,
       variant: 'info',
     })
-    setTimeout(fetchModels, 2000)
+    setTimeout(() => {
+      fetchModels()
+      triggerGpuRefresh()
+    }, 2000)
   }
 
   const handleUnloadAll = async () => {
@@ -268,6 +331,7 @@ function ModelManagement() {
         variant: 'success',
       })
       await fetchModels()
+      triggerGpuRefresh()
     } catch (err) {
       addNotification({
         title: 'Error unloading models',
@@ -436,7 +500,7 @@ function ModelManagement() {
 
         {/* GPU Memory Overview Panel */}
         <div style={{ marginTop: 'var(--pf-t--global--spacer--lg)' }}>
-          <GpuMemoryPanel onModelClick={handleMemoryBarClick} />
+          <GpuMemoryPanel onModelClick={handleMemoryBarClick} refreshTrigger={gpuRefreshTrigger} />
         </div>
 
         {models.length === 0 ? (
@@ -506,7 +570,11 @@ function ModelManagement() {
                       isExpanded={expandedGpuGroups.has(gpuKey)}
                       onToggle={handleGpuGroupToggle}
                       onUnload={handleUnloadModel}
+                      onSleep={handleSleepModel}
+                      onWake={handleWakeModel}
                       unloadingInstanceId={unloadingInstanceId}
+                      sleepingInstanceId={sleepingInstanceId}
+                      wakingInstanceId={wakingInstanceId}
                       expandedCards={expandedCards}
                       onCardToggle={handleCardToggle}
                     />
@@ -520,7 +588,11 @@ function ModelManagement() {
                   sortDirection={sortDirection}
                   onSort={handleTableSort}
                   onUnload={handleUnloadModel}
+                  onSleep={handleSleepModel}
+                  onWake={handleWakeModel}
                   unloadingInstanceId={unloadingInstanceId}
+                  sleepingInstanceId={sleepingInstanceId}
+                  wakingInstanceId={wakingInstanceId}
                 />
               )}
             </div>

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -24,6 +24,9 @@ import type {
   LoginRequest,
   LoginResponse,
   CurrentUserResponse,
+  SleepModelResponse,
+  WakeModelResponse,
+  SleepStatusResponse,
 } from '@sardeenz/types'
 
 // Memory Profile types for API responses
@@ -452,6 +455,29 @@ class ApiClient {
   async unloadModelByInstanceId(instanceId: string): Promise<UnloadModelResponse> {
     const response = await this.client.delete<UnloadModelResponse>(
       `/api/models/instances/${instanceId}`
+    )
+    return response.data
+  }
+
+  async sleepModel(instanceId: string, level: 1 | 2 = 1): Promise<SleepModelResponse> {
+    const response = await this.client.post<SleepModelResponse>(
+      `/api/models/instances/${instanceId}/sleep`,
+      { level }
+    )
+    return response.data
+  }
+
+  async wakeModel(instanceId: string, tags?: 'weights' | 'kv_cache'): Promise<WakeModelResponse> {
+    const response = await this.client.post<WakeModelResponse>(
+      `/api/models/instances/${instanceId}/wake`,
+      tags ? { tags } : {}
+    )
+    return response.data
+  }
+
+  async getSleepStatus(instanceId: string): Promise<SleepStatusResponse> {
+    const response = await this.client.get<SleepStatusResponse>(
+      `/api/models/instances/${instanceId}/sleep-status`
     )
     return response.data
   }

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -7,6 +7,7 @@ This guide provides practical examples for using the Sardeenz APIs.
 - [Overview](#overview)
 - [Authentication](#authentication)
 - [Controller API](#controller-api)
+- [Sleep Mode API](#sleep-mode-api)
 - [GPU API](#gpu-api)
 - [Direct Proxy API](#direct-proxy-api)
 - [Proxy API](#proxy-api)
@@ -286,6 +287,7 @@ When authenticated with the `admin-readonly` role, the frontend displays visual 
 | `gpu_ids`              | number[] | No       | GPU indices to use. If omitted, auto-selects GPU(s) with most free memory        |
 | `tensor_parallel_size` | number   | No       | Number of GPUs for tensor parallelism (default: 1). kvcached is disabled when >1 |
 | `extra_args`           | string[] | No       | Additional vLLM CLI arguments                                                    |
+| `enable_sleep_mode`    | boolean  | No       | Enable sleep mode for this model. When enabled, the model can be put to sleep to free GPU memory (~90%) while remaining loaded for quick wake-up. See [Sleep Mode API](#sleep-mode-api). |
 
 **Response (202 Accepted):**
 
@@ -772,6 +774,164 @@ Each GPU with loaded models includes a `kvcache` object with per-GPU KVCache met
 The KVCache total is calculated dynamically as: `GPU Total - Model Baselines - Other Processes`. This replaces the old approach of reading a stale `total_size` from the IPC segment.
 
 **Note:** For tensor-parallel models spanning multiple GPUs, KVCache usage is split evenly across participating GPUs.
+
+## Sleep Mode API
+
+Sleep mode allows models to be put to sleep to free GPU memory (~90%) while remaining loaded for quick wake-up. This is useful for models that are not frequently used but need to be available on short notice.
+
+> **Important:** Sleep mode must be enabled when loading the model via the `enable_sleep_mode` parameter. Models loaded without this flag cannot be put to sleep.
+
+### How Sleep Mode Works
+
+vLLM's sleep mode offloads model weights from GPU to CPU RAM:
+
+| Level | Action | Memory Freed | Use Case |
+| ----- | ------ | ------------ | -------- |
+| 1 | Offload weights to CPU RAM, discard KV cache | ~90% | Quick sleep/wake cycles |
+| 2 | Discard weights and KV cache entirely | ~95% | Model switching, RLHF |
+
+Wake-up reloads the weights from CPU back to GPU, which is faster than loading from disk.
+
+### Put Model to Sleep
+
+**Endpoint:** `POST /api/models/instances/:instance_id/sleep`
+
+Puts a running model to sleep to free GPU memory.
+
+**Query Parameters:**
+
+| Parameter | Type   | Default | Description                                      |
+| --------- | ------ | ------- | ------------------------------------------------ |
+| `level`   | number | 1       | Sleep level: 1 (offload to CPU) or 2 (discard)   |
+
+**Response (200 OK):**
+
+```json
+{
+  "status": "success",
+  "instance_id": "llama-3-2-1b-abc123",
+  "model_path": "meta-llama/Llama-3.2-1B",
+  "sleep_level": 1,
+  "slept_at": "2025-11-29T12:00:00Z"
+}
+```
+
+**Error Responses:**
+
+| Status | Condition | Message |
+| ------ | --------- | ------- |
+| 400 | Sleep mode not enabled | Model was not loaded with sleep mode enabled |
+| 404 | Instance not found | Model instance {id} not found |
+| 409 | Model not running | Cannot sleep model: current status is {status} |
+
+**Example (curl):**
+
+```bash
+# Put model to sleep (level 1 - offload to CPU)
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:3000/api/models/instances/abc123/sleep?level=1"
+
+# Put model to deep sleep (level 2 - discard)
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:3000/api/models/instances/abc123/sleep?level=2"
+```
+
+### Wake Up Model
+
+**Endpoint:** `POST /api/models/instances/:instance_id/wake`
+
+Wakes a sleeping model, restoring it to running state.
+
+**Request Body (optional):**
+
+```json
+{
+  "tags": "weights"
+}
+```
+
+**Request Fields:**
+
+| Field  | Type   | Required | Description                                                              |
+| ------ | ------ | -------- | ------------------------------------------------------------------------ |
+| `tags` | string | No       | What to reload: `weights` (model weights) or `kv_cache` (KV cache data) |
+
+**Response (200 OK):**
+
+```json
+{
+  "status": "success",
+  "instance_id": "llama-3-2-1b-abc123",
+  "model_path": "meta-llama/Llama-3.2-1B",
+  "woke_at": "2025-11-29T12:05:00Z"
+}
+```
+
+**Error Responses:**
+
+| Status | Condition | Message |
+| ------ | --------- | ------- |
+| 404 | Instance not found | Model instance {id} not found |
+| 409 | Model not sleeping | Model is not sleeping |
+
+**Example (curl):**
+
+```bash
+# Wake up model
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:3000/api/models/instances/abc123/wake"
+```
+
+### Get Sleep Status
+
+**Endpoint:** `GET /api/models/instances/:instance_id/sleep-status`
+
+Returns the current sleep status of a model instance.
+
+**Response (200 OK):**
+
+```json
+{
+  "instance_id": "llama-3-2-1b-abc123",
+  "is_sleeping": true,
+  "sleep_level": 1
+}
+```
+
+When the model is not sleeping:
+
+```json
+{
+  "instance_id": "llama-3-2-1b-abc123",
+  "is_sleeping": false
+}
+```
+
+**Example (curl):**
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:3000/api/models/instances/abc123/sleep-status"
+```
+
+### Sleep Mode and Inference
+
+When a model is sleeping, inference requests to that model will receive a 503 error:
+
+```json
+{
+  "error": {
+    "message": "Model {model_name} is sleeping. Wake it up to serve requests.",
+    "type": "service_unavailable",
+    "code": "model_sleeping"
+  }
+}
+```
+
+Wake the model before sending inference requests.
 
 ## GPU API
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,8 +239,13 @@ python -m vllm.entrypoints.openai.api_server \
 **Lifecycle States:**
 - `starting` → Process spawning, waiting for API readiness
 - `active` → Serving requests
+- `sleeping` → Sleep mode active (GPU memory freed, model weights in CPU RAM)
 - `stopping` → Graceful shutdown in progress
 - `failed` → Process crashed or failed health check
+
+**Sleep Mode:**
+
+Models loaded with `enable_sleep_mode=true` can be put to sleep to free GPU memory (~90%) while remaining loaded for quick wake-up. Sleep mode offloads model weights from GPU to CPU RAM (level 1) or discards them entirely (level 2). See [Sleep Mode API](./api-guide.md#sleep-mode-api) for details.
 
 **Background Monitoring:**
 
@@ -270,7 +275,7 @@ interface ModelInstance {
   id: string;                      // Unique instance ID
   modelPath: string;               // Path to model files
   displayName: string;             // Human-readable name
-  status: 'starting' | 'active' | 'stopping' | 'failed';
+  status: 'starting' | 'active' | 'sleeping' | 'stopping' | 'failed';
   port: number;                    // vLLM API port
   processId: number;               // API Server PID (from spawn)
   engineCorePid?: number;          // EngineCore PID (allocates GPU VRAM)
@@ -283,6 +288,11 @@ interface ModelInstance {
   stoppedAt?: Date;
   errorMessage?: string;
   memoryMetrics?: ModelMemoryMetrics; // Parsed from vLLM logs after loading
+
+  // Sleep mode (requires --enable-sleep-mode flag at load)
+  sleepModeEnabled: boolean;       // Whether sleep mode is enabled for this instance
+  sleepLevel?: 1 | 2;              // Current sleep level (1=CPU offload, 2=discard)
+  sleptAt?: Date;                  // When the model went to sleep
 }
 
 interface ModelMemoryMetrics {

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -38,6 +38,17 @@ Core service managing vLLM subprocess lifecycle:
 - **SIGKILL unload**: Uses SIGKILL (not SIGTERM) to bypass Python cleanup that would delete shared IPC
 - **EngineCore PID tracking**: Extracts GPU-using process PID from logs for accurate memory monitoring
 - **Conflict group detection**: Union-Find algorithm groups models sharing any GPU for sequential loading
+- **Sleep mode**: Put models to sleep to free GPU memory (~90%) while remaining loaded for quick wake-up
+
+**Sleep Mode Methods:**
+
+| Method | Description |
+| ------ | ----------- |
+| `sleepModel(instanceId, level)` | Puts a running model to sleep. Level 1 offloads weights to CPU RAM, Level 2 discards weights. Requires model to be loaded with `enableSleepMode: true`. |
+| `wakeModel(instanceId, tags?)` | Wakes a sleeping model, restoring it to running state. Optionally specify `tags` to reload only specific components (weights, kv_cache). |
+| `isSleeping(instanceId)` | Returns whether the model is currently sleeping and at what level. |
+
+Sleep mode requires the `--enable-sleep-mode` vLLM flag and `VLLM_SERVER_DEV_MODE=1` environment variable, which are automatically set when `enableSleepMode: true` is passed to `launchModel()`.
 
 ### ProcessLogBuffer (`src/services/process-log-buffer.ts`)
 

--- a/docs/architecture/frontend-architecture.md
+++ b/docs/architecture/frontend-architecture.md
@@ -568,7 +568,7 @@ export function useWebSocket(url: string) {
 
 ## Key Component Specifications
 
-### 1. ModelCard
+### 1. ModelCard / ModelCardCompact
 
 **Purpose:** Display a single model instance with status, GPU placement, and actions.
 
@@ -577,7 +577,11 @@ export function useWebSocket(url: string) {
 interface ModelCardProps {
   model: ModelInstanceDTO;
   onUnload: (instanceId: string, modelPath: string, isFailed: boolean) => void;
+  onSleep?: (instanceId: string) => void;
+  onWake?: (instanceId: string) => void;
   isUnloading?: boolean;
+  isSleeping?: boolean;
+  isWaking?: boolean;
 }
 ```
 
@@ -587,6 +591,8 @@ interface ModelCardProps {
 - `Badge` (via `ModelStatusBadge` for status)
 - `Button` (for actions)
 - `ExpandableSection` (for launch command)
+- `Dropdown` with `DropdownItem` for actions menu
+- `MoonIcon`, `SunIcon` (for sleep/wake actions)
 
 **Layout:**
 ```
@@ -628,6 +634,7 @@ interface LoadModelConfig {
   displayName: string;
   gpuMemoryLimit: number; // 0.1 - 0.9
   port?: number; // Optional, auto-assign if not provided
+  enableSleepMode?: boolean; // Enable sleep mode for this model
 }
 ```
 
@@ -637,6 +644,7 @@ interface LoadModelConfig {
 - `TextInput` (model path, display name)
 - `Slider` (GPU memory allocation)
 - `NumberInput` (port, optional)
+- `Checkbox` (Enable Sleep Mode)
 - `Button` (Load, Cancel)
 
 **Validation:**
@@ -644,6 +652,7 @@ interface LoadModelConfig {
 - Display name: Required, max 50 chars
 - GPU memory: 0.1-0.9 (10%-90%)
 - Port: Optional, 1024-65535
+- Enable Sleep Mode: Optional checkbox to allow the model to be put to sleep later
 
 ### 3. MemoryUsageChart
 
@@ -677,17 +686,19 @@ interface MemoryUsageChartProps {
 **Props:**
 ```tsx
 interface ModelStatusBadgeProps {
-  status: 'starting' | 'active' | 'stopping' | 'failed';
+  status: 'starting' | 'active' | 'sleeping' | 'stopping' | 'failed';
 }
 ```
 
 **PatternFly Components:**
 - `Badge`
-- `Spinner` (for 'starting' status)
+- `Spinner` (for 'starting', 'stopping' status)
+- `MoonIcon` (for 'sleeping' status)
 
 **Color Mapping:**
 - `starting` → Blue badge with spinner
 - `active` → Green badge
+- `sleeping` → Purple badge with moon icon
 - `stopping` → Orange badge with spinner
 - `failed` → Red badge
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -13,6 +13,7 @@ export interface LoadModelRequest {
   tensor_parallel_size?: number // For large models spanning multiple GPUs (default: 1)
   source_type?: ModelSourceType // Model source type (default: 'huggingface')
   served_model_name?: string // Name for vLLM --served-model-name (default: model_path)
+  enable_sleep_mode?: boolean // Enable vLLM sleep mode for GPU memory offloading
 }
 
 export interface LoadModelResponse {
@@ -68,6 +69,9 @@ export interface ModelInstanceDTO {
   tensor_parallel_size: number // 1 = single GPU, >1 = spanning multiple GPUs
   kvcached_enabled: boolean // Whether kvcached is enabled (false for tensor parallel)
   memory_baseline_by_gpu?: Record<number, number> // Memory baseline per GPU in GB
+  sleep_mode_enabled: boolean // Whether sleep mode is enabled for this instance
+  sleep_level?: 1 | 2 // Current sleep level if sleeping
+  slept_at?: string // ISO timestamp when model went to sleep
 }
 
 export interface GetModelResponse {
@@ -104,6 +108,7 @@ export interface ModelGpuMemory {
   display_name: string // Short name for legend, unique per instance (e.g., "Llama-3.2-1B", "Llama-3.2-1B (2)")
   gpu_memory_gb: number // Model's GPU footprint (weights + CUDA graphs)
   color: string // Assigned color for visualization
+  is_sleeping?: boolean // Whether model is currently sleeping
 }
 
 export interface MemoryUsageResponse {
@@ -356,4 +361,42 @@ export interface ListLocalModelsResponse {
 export interface LocalModelsStatusResponse {
   enabled: boolean
   path?: string
+}
+
+// Sleep Mode API types
+
+/** Request to put a model to sleep */
+export interface SleepModelRequest {
+  /** Sleep level: 1 = offload weights to CPU, 2 = discard weights and KV cache */
+  level?: 1 | 2
+}
+
+/** Response after putting a model to sleep */
+export interface SleepModelResponse {
+  status: 'success'
+  instance_id: string
+  model_path: string
+  sleep_level: 1 | 2
+  slept_at: string
+}
+
+/** Request to wake a sleeping model */
+export interface WakeModelRequest {
+  /** Optional tags for selective wake (vLLM-specific) */
+  tags?: 'weights' | 'kv_cache'
+}
+
+/** Response after waking a model */
+export interface WakeModelResponse {
+  status: 'success'
+  instance_id: string
+  model_path: string
+  woke_at: string
+}
+
+/** Response for checking sleep status */
+export interface SleepStatusResponse {
+  instance_id: string
+  is_sleeping: boolean
+  sleep_level?: 1 | 2
 }

--- a/packages/types/src/model-configuration.ts
+++ b/packages/types/src/model-configuration.ts
@@ -20,6 +20,7 @@ export interface ModelConfigurationEntry {
   gpuIds?: number[]
   tensorParallelSize: number
   loadOrder: number
+  sleepModeEnabled?: boolean
 }
 
 /**

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -89,6 +89,12 @@ export interface ModelInstance {
   kvcachedEnabled: boolean
   /** Memory baseline per GPU in GB (captured when model becomes 'running', before any inference) */
   memoryBaselineByGpu: Record<number, number>
+  /** Whether sleep mode is enabled for this instance (requires --enable-sleep-mode flag) */
+  sleepModeEnabled: boolean
+  /** Current sleep level if sleeping (1 = weights to CPU, 2 = discard all) */
+  sleepLevel?: 1 | 2
+  /** Timestamp when model went to sleep */
+  sleptAt?: Date
 }
 
 export interface InferenceRequest {

--- a/packages/types/src/schemas/model-configuration.ts
+++ b/packages/types/src/schemas/model-configuration.ts
@@ -20,6 +20,7 @@ export const ModelConfigurationEntrySchema = Type.Object({
   gpu_ids: Type.Optional(Type.Array(Type.Integer())),
   tensor_parallel_size: Type.Integer(),
   load_order: Type.Integer(),
+  sleep_mode_enabled: Type.Optional(Type.Boolean()),
 })
 
 // Configuration schema for API responses

--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -62,6 +62,7 @@ export const LoadModelRequestSchema = Type.Object({
   tensor_parallel_size: Type.Optional(Type.Integer({ minimum: 1, maximum: 8 })),
   source_type: Type.Optional(ModelSourceTypeSchema),
   served_model_name: Type.Optional(Type.String({ minLength: 1 })),
+  enable_sleep_mode: Type.Optional(Type.Boolean()),
 })
 
 export const LoadModelResponseSchema = Type.Object({
@@ -104,6 +105,9 @@ export const ModelInstanceDTOSchema = Type.Object({
   gpu_ids: Type.Array(Type.Integer()),
   tensor_parallel_size: Type.Integer(),
   kvcached_enabled: Type.Boolean(),
+  sleep_mode_enabled: Type.Boolean(),
+  sleep_level: Type.Optional(Type.Union([Type.Literal(1), Type.Literal(2)])),
+  slept_at: Type.Optional(Type.String({ format: 'date-time' })),
 })
 
 export const ListModelsResponseSchema = Type.Object({
@@ -244,6 +248,7 @@ export const ModelGpuMemorySchema = Type.Object({
   display_name: Type.String(),
   gpu_memory_gb: Type.Number(),
   color: Type.String(),
+  is_sleeping: Type.Optional(Type.Boolean()),
 })
 
 export const KVCacheMetricsSchema = Type.Object({
@@ -371,3 +376,41 @@ export type DetokenizeRequest = Static<typeof DetokenizeRequestSchema>
 export type VLLMGenericRequest = Static<typeof VLLMGenericRequestSchema>
 export type VLLMModel = Static<typeof VLLMModelSchema>
 export type VLLMModelsListResponse = Static<typeof VLLMModelsListResponseSchema>
+
+// Sleep Mode schemas
+export const SleepLevelSchema = Type.Union([Type.Literal(1), Type.Literal(2)])
+
+export const SleepModelRequestSchema = Type.Object({
+  level: Type.Optional(SleepLevelSchema),
+})
+
+export const SleepModelResponseSchema = Type.Object({
+  status: Type.Literal('success'),
+  instance_id: Type.String({ format: 'uuid' }),
+  model_path: Type.String(),
+  sleep_level: SleepLevelSchema,
+  slept_at: Type.String({ format: 'date-time' }),
+})
+
+export const WakeModelRequestSchema = Type.Object({
+  tags: Type.Optional(Type.Union([Type.Literal('weights'), Type.Literal('kv_cache')])),
+})
+
+export const WakeModelResponseSchema = Type.Object({
+  status: Type.Literal('success'),
+  instance_id: Type.String({ format: 'uuid' }),
+  model_path: Type.String(),
+  woke_at: Type.String({ format: 'date-time' }),
+})
+
+export const SleepStatusResponseSchema = Type.Object({
+  instance_id: Type.String({ format: 'uuid' }),
+  is_sleeping: Type.Boolean(),
+  sleep_level: Type.Optional(SleepLevelSchema),
+})
+
+export type SleepModelRequestType = Static<typeof SleepModelRequestSchema>
+export type SleepModelResponseType = Static<typeof SleepModelResponseSchema>
+export type WakeModelRequestType = Static<typeof WakeModelRequestSchema>
+export type WakeModelResponseType = Static<typeof WakeModelResponseSchema>
+export type SleepStatusResponseType = Static<typeof SleepStatusResponseSchema>


### PR DESCRIPTION
Allow models to be put to sleep to free ~90% of GPU memory while
keeping them loaded for quick wake-up. This enables efficient
multi-model hosting by temporarily freeing GPU resources.

Changes:
- Add sleep/wake API endpoints for model instances
- Support sleep level 1 (offload weights to CPU RAM)
- Support sleep level 2 (discard weights and KV cache)
- Add "Enable Sleep Mode" checkbox in Load Model dialog
- Add sleep/wake actions with moon/sun icons in model menus
- Add purple "sleeping" status badge with moon icon
- Proxy returns 503 with clear message for sleeping models
- Persist sleep_mode_enabled in model configurations

API endpoints:
- POST /api/models/instances/:id/sleep
- POST /api/models/instances/:id/wake
- GET /api/models/instances/:id/sleep-status

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
