### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **OAuth state in cluster mode**: Moved OAuth state storage from in-memory Map to PostgreSQL, fixing login failures when OAuth callbacks land on a different pod than the one that initiated the flow
+- **Pre-Ampere GPU support**: Auto-detect GPUs with compute capability < 8.0 (T4, V100, P100, etc.) and override the attention backend to TRITON_ATTN via the `--attention-backend` CLI argument, since FlashInfer kernels are not available on these architectures
+
 ## [0.7.0] - 2026-05-19
 
 ### School of Sardeenz — Multi-Pod Cluster Orchestration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-09
+
 ### Bug Fixes
 
 - **OAuth state in cluster mode**: Moved OAuth state storage from in-memory Map to PostgreSQL, fixing login failures when OAuth callbacks land on a different pod than the one that initiated the flow
 - **Pre-Ampere GPU support**: Auto-detect GPUs with compute capability < 8.0 (T4, V100, P100, etc.) and override the attention backend to TRITON_ATTN via the `--attention-backend` CLI argument, since FlashInfer kernels are not available on these architectures
+- **Leader-redirect OAuth hostname**: Preserve the external hostname when leader-redirect forwards OAuth login requests, preventing redirect URI mismatches
+- **Leader-redirect URL fragments**: Prevent leader-redirect from following redirects and dropping URL hash fragments
+- **Dashboard background colors**: Fixed background color inconsistencies in the frontend
 
 ## [0.7.0] - 2026-05-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ npm run build -w packages/utils
 npm run dev
 ```
 
-**Prerequisites:** Node.js 22.x, Python 3.12 + uv, NVIDIA GPU with CUDA 12.x, 8GB+ VRAM (16GB+ recommended)
+**Prerequisites:** Node.js 22.x, Python 3.12 + uv, NVIDIA GPU with CUDA 13.x, 8GB+ VRAM (16GB+ recommended)
 
 **GPU Setup:** On first run, the backend auto-creates a Python venv with vLLM/kvcached. See [`docs/dev-setup.md`](./docs/dev-setup.md) for details.
 

--- a/apps/backend/scripts/start-dev.sh
+++ b/apps/backend/scripts/start-dev.sh
@@ -9,7 +9,7 @@
 #
 # Prerequisites:
 # - uv (Python package manager): curl -LsSf https://astral.sh/uv/install.sh | sh
-# - NVIDIA GPU with CUDA 12.x drivers
+# - NVIDIA GPU with CUDA 13.x drivers
 # - Python 3.12
 #
 # Options:

--- a/apps/backend/src/db/migrations/008-oauth-state.sql
+++ b/apps/backend/src/db/migrations/008-oauth-state.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS oauth_states (
+  state TEXT PRIMARY KEY,
+  callback_url TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_states_created_at ON oauth_states (created_at)

--- a/apps/backend/src/plugins/leader-redirect.ts
+++ b/apps/backend/src/plugins/leader-redirect.ts
@@ -101,6 +101,10 @@ export default fp(
       const forwardHeaders = filterHeaders(request.headers as Record<string, string | string[] | undefined>)
       forwardHeaders['x-sardeenz-forwarded'] = 'true'
       forwardHeaders['x-forwarded-for'] = request.ip
+      // Preserve original host so the leader can construct correct external URLs (e.g. OAuth redirect_uri)
+      if (request.headers.host && !forwardHeaders['x-forwarded-host']) {
+        forwardHeaders['x-forwarded-host'] = request.headers.host as string
+      }
 
       const hasBody = request.method !== 'GET' && request.method !== 'HEAD' && request.method !== 'OPTIONS'
 
@@ -112,6 +116,7 @@ export default fp(
           body: hasBody ? (request.raw as unknown as ReadableStream) : undefined,
           signal: AbortSignal.timeout(FORWARD_TIMEOUT_MS),
           duplex: hasBody ? 'half' : undefined,
+          redirect: 'manual',
         })
       } catch (err: unknown) {
         const isTimeout = err instanceof DOMException && err.name === 'TimeoutError'

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -3,6 +3,7 @@ import { Type, type Static } from '@sinclair/typebox'
 import { randomBytes, timingSafeEqual } from 'crypto'
 import { readFileSync, existsSync } from 'fs'
 import { config } from '../config.js'
+import { oauthStateStore } from '../stores/oauth-state-store.js'
 
 /**
  * Timing-safe string comparison to prevent timing attacks
@@ -68,23 +69,6 @@ const ErrorResponseSchema = Type.Object({
   }),
 })
 
-// In-memory state storage for OAuth CSRF protection
-// Maps state -> { callbackUrl, createdAt }
-const oauthStateStore = new Map<string, { callbackUrl: string; createdAt: number }>()
-const STATE_TTL_MS = 5 * 60 * 1000 // 5 minutes
-
-// Clean up expired states periodically
-function cleanupExpiredStates(): void {
-  const now = Date.now()
-  for (const [state, data] of oauthStateStore.entries()) {
-    if (now - data.createdAt > STATE_TTL_MS) {
-      oauthStateStore.delete(state)
-    }
-  }
-}
-
-// Run cleanup every minute
-setInterval(cleanupExpiredStates, 60 * 1000)
 
 /**
  * Get the ServiceAccount token for making K8s API calls
@@ -201,6 +185,16 @@ interface OpenShiftUserInfo {
 }
 
 export default async function authRoutes(fastify: FastifyInstance) {
+  // Periodically clean up expired OAuth states from PostgreSQL
+  const cleanupInterval = setInterval(() => {
+    oauthStateStore.cleanup().catch((err) => {
+      fastify.log.warn(err, 'Failed to clean up expired OAuth states')
+    })
+  }, 60 * 1000)
+
+  fastify.addHook('onClose', () => {
+    clearInterval(cleanupInterval)
+  })
   /**
    * GET /api/auth/info
    * Returns authentication configuration for the frontend
@@ -256,15 +250,17 @@ export default async function authRoutes(fastify: FastifyInstance) {
       const state = randomBytes(32).toString('hex')
 
       // Determine callback URL based on request origin
+      // Use request.host (proxy-aware via trustProxy) instead of raw Host header,
+      // so forwarded requests from follower pods resolve the correct external hostname
       const origin =
         request.headers.origin ||
-        (request.headers.host ? `${request.protocol}://${request.headers.host}` : null)
+        (request.host ? `${request.protocol}://${request.host}` : null)
       const callbackUrl = origin
         ? `${origin}/api/auth/callback`
         : `${config.apiBaseUrl}/api/auth/callback`
 
-      // Store state for validation
-      oauthStateStore.set(state, { callbackUrl, createdAt: Date.now() })
+      // Store state in PostgreSQL for cross-pod validation
+      await oauthStateStore.save(state, callbackUrl)
 
       // Build authorization URL
       const params = new URLSearchParams({
@@ -424,17 +420,14 @@ export default async function authRoutes(fastify: FastifyInstance) {
         )
       }
 
-      // Validate state (CSRF protection)
-      const storedState = oauthStateStore.get(state)
+      // Validate and consume state atomically (CSRF protection)
+      const storedState = await oauthStateStore.consume(state)
       if (!storedState) {
         fastify.log.warn({ state }, 'Invalid or expired OAuth state')
         return reply.redirect(
           `${config.frontendUrl}/?auth_error=${encodeURIComponent('Invalid or expired state. Please try logging in again.')}`
         )
       }
-
-      // Remove used state
-      oauthStateStore.delete(state)
 
       const callbackUrl = storedState.callbackUrl
 

--- a/apps/backend/src/routes/cluster/models.ts
+++ b/apps/backend/src/routes/cluster/models.ts
@@ -68,6 +68,7 @@ export default async function clusterModelRoutes(fastify: FastifyInstance) {
             instanceId: Type.String(),
             podId: Type.String(),
             status: Type.String(),
+            warnings: Type.Optional(Type.Array(Type.String())),
           }),
           400: ErrorSchema,
           404: ErrorSchema,
@@ -102,7 +103,12 @@ export default async function clusterModelRoutes(fastify: FastifyInstance) {
             servedModelName,
             enableSleepMode,
           })
-          return { instanceId: instance.id, podId, status: instance.status }
+          return {
+            instanceId: instance.id,
+            podId,
+            status: instance.status,
+            ...(instance.warnings?.length ? { warnings: instance.warnings } : {}),
+          }
         } catch (err) {
           fastify.log.error({ err, modelPath }, 'Local cluster load failed')
           return reply.code(500).send({ error: (err as Error).message })
@@ -129,13 +135,18 @@ export default async function clusterModelRoutes(fastify: FastifyInstance) {
           signal: AbortSignal.timeout(10_000),
         })
 
-        const result = await response.json() as { instanceId?: string; status?: string; error?: string }
+        const result = await response.json() as { instanceId?: string; status?: string; warnings?: string[]; error?: string }
 
         if (!response.ok) {
           return reply.code(response.status).send({ error: result.error ?? 'Remote load failed' })
         }
 
-        return { instanceId: result.instanceId, podId, status: result.status }
+        return {
+          instanceId: result.instanceId,
+          podId,
+          status: result.status,
+          ...(result.warnings?.length ? { warnings: result.warnings } : {}),
+        }
       } catch (err) {
         fastify.log.error({ err, podId, modelPath }, 'Failed to forward load to remote pod')
         return reply.code(502).send({ error: `Failed to reach pod ${podId}` })

--- a/apps/backend/src/routes/internal.ts
+++ b/apps/backend/src/routes/internal.ts
@@ -258,6 +258,7 @@ export default async function internalRoutes(fastify: FastifyInstance) {
             properties: {
               instanceId: { type: 'string' },
               status: { type: 'string' },
+              warnings: { type: 'array', items: { type: 'string' } },
             },
           },
         },
@@ -278,7 +279,11 @@ export default async function internalRoutes(fastify: FastifyInstance) {
           enableSleepMode,
         })
 
-        return { instanceId: instance.id, status: instance.status }
+        return {
+          instanceId: instance.id,
+          status: instance.status,
+          ...(instance.warnings?.length ? { warnings: instance.warnings } : {}),
+        }
       } catch (err) {
         fastify.log.error({ err, modelPath }, 'Remote load command failed')
         return reply.code(500).send({ error: (err as Error).message })

--- a/apps/backend/src/routes/models.ts
+++ b/apps/backend/src/routes/models.ts
@@ -110,6 +110,7 @@ export default async function modelsRoutes(fastify: FastifyInstance) {
           port: instance.port,
           loaded_at: instance.loadedAt.toISOString(),
           instance_id: instance.id,
+          ...(instance.warnings?.length ? { warnings: instance.warnings } : {}),
         }
       } catch (err) {
         // This only catches spawn failures, not loading failures

--- a/apps/backend/src/services/model-manager.ts
+++ b/apps/backend/src/services/model-manager.ts
@@ -18,7 +18,7 @@ import { NotFoundError, InternalError } from '../utils/errors.js'
 import { buildErrorMessage } from '../utils/error-parser.js'
 import { parseMemoryMetrics, extractEngineCorePid } from '../utils/memory-parser.js'
 import { LoadProgressTracker } from '../utils/load-progress-tracker.js'
-import { getNvidiaSmiInfo } from '../utils/gpu-info.js'
+import { getNvidiaSmiInfo, getCachedGpuInfo, needsAttentionBackendOverride } from '../utils/gpu-info.js'
 import { simGpuTracker } from '../utils/sim-gpu-tracker.js'
 import { estimateModelMemory } from '../utils/model-memory-estimator.js'
 import type { Logger } from '@sardeenz/utils'
@@ -269,6 +269,32 @@ export class ModelManager extends EventEmitter {
         }
 
         allArgs = [...baseArgs, ...sanitizedExtraArgs]
+
+        // Detect if GPUs need attention backend override (pre-Ampere GPUs like T4)
+        // FlashInfer kernels require compute capability >= 8.0
+        let needsAttentionOverride = false
+        const gpuInfoList = getCachedGpuInfo()
+        if (
+          gpuInfoList &&
+          !hasArg(sanitizedExtraArgs, '--attention-backend')
+        ) {
+          const targetGpuNames = targetGpuIds
+            .map((id) => gpuInfoList.find((g) => g.index === id))
+            .filter((g) => g !== undefined)
+
+          needsAttentionOverride = targetGpuNames.some((g) => needsAttentionBackendOverride(g.name))
+          if (needsAttentionOverride) {
+            const gpuName = targetGpuNames[0]?.name ?? 'unknown'
+            this.logger.warn(
+              { gpuName, targetGpuIds },
+              'GPU does not support FlashInfer (compute capability < 8.0), overriding attention backend to TRITON_ATTN'
+            )
+            allArgs.push('--attention-backend', 'TRITON_ATTN')
+            instance.warnings = [
+              `${gpuName} does not support the FlashInfer attention backend — using TRITON_ATTN instead.`,
+            ]
+          }
+        }
 
         const kvcachedIpcName = enableKvcached ? buildIpcSegmentName(targetGpuIds) : undefined
         const cudaVisibleDevices = config.virtualGpuCount > 0 ? '0' : targetGpuIds.join(',')

--- a/apps/backend/src/stores/oauth-state-store.ts
+++ b/apps/backend/src/stores/oauth-state-store.ts
@@ -1,0 +1,45 @@
+import { getPool } from '../db/index.js'
+
+const STATE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
+interface OAuthState {
+  callbackUrl: string
+  createdAt: number
+}
+
+class OAuthStateStore {
+  async save(state: string, callbackUrl: string): Promise<void> {
+    const pool = getPool()
+    await pool.query('INSERT INTO oauth_states (state, callback_url) VALUES ($1, $2)', [
+      state,
+      callbackUrl,
+    ])
+  }
+
+  async consume(state: string): Promise<OAuthState | null> {
+    const pool = getPool()
+    const result = await pool.query(
+      `DELETE FROM oauth_states
+       WHERE state = $1
+         AND created_at > NOW() - INTERVAL '${STATE_TTL_MS / 1000} seconds'
+       RETURNING callback_url, created_at`,
+      [state]
+    )
+
+    if (result.rows.length === 0) return null
+
+    return {
+      callbackUrl: result.rows[0].callback_url,
+      createdAt: new Date(result.rows[0].created_at).getTime(),
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    const pool = getPool()
+    await pool.query(
+      `DELETE FROM oauth_states WHERE created_at < NOW() - INTERVAL '${STATE_TTL_MS / 1000} seconds'`
+    )
+  }
+}
+
+export const oauthStateStore = new OAuthStateStore()

--- a/apps/backend/src/utils/gpu-info.ts
+++ b/apps/backend/src/utils/gpu-info.ts
@@ -65,6 +65,81 @@ export interface NvidiaSmiInfo {
 
 const DEFAULT_GPU_MEMORY_GB = 24.0
 
+// FlashInfer attention backend requires compute capability >= 8.0 (Ampere+)
+const MIN_FLASHINFER_COMPUTE_CAPABILITY = 8.0
+
+// GPU name patterns → compute capability (major.minor)
+// Used to detect pre-Ampere GPUs that need attention backend fallback
+const GPU_COMPUTE_CAPABILITIES: [RegExp, number][] = [
+  // Blackwell (10.0+)
+  [/\bB100\b/i, 10.0],
+  [/\bB200\b/i, 10.0],
+  [/\bGB200\b/i, 10.0],
+  // Hopper (9.0)
+  [/\bH100\b/i, 9.0],
+  [/\bH200\b/i, 9.0],
+  [/\bGH200\b/i, 9.0],
+  // Ada Lovelace (8.9)
+  [/\bL4\b/i, 8.9],
+  [/\bL40S?\b/i, 8.9],
+  [/\bRTX\s*40\d\d/i, 8.9],
+  [/\bRTX\s*6000\s*Ada/i, 8.9],
+  // Ampere (8.0-8.6)
+  [/\bA100\b/i, 8.0],
+  [/\bA10\b/i, 8.6],
+  [/\bA10G\b/i, 8.6],
+  [/\bA16\b/i, 8.6],
+  [/\bA30\b/i, 8.0],
+  [/\bA40\b/i, 8.6],
+  [/\bA2\b/i, 8.6],
+  [/\bRTX\s*30\d\d/i, 8.6],
+  [/\bRTX\s*A[2-6]000/i, 8.6],
+  // Turing (7.5) - pre-Ampere
+  [/\bT4\b/i, 7.5],
+  [/\bTITAN\s*RTX\b/i, 7.5],
+  [/\bRTX\s*20\d\d/i, 7.5],
+  [/\bGTX\s*16\d\d/i, 7.5],
+  [/\bQuadro\s*RTX/i, 7.5],
+  // Volta (7.0) - pre-Ampere
+  [/\bV100\b/i, 7.0],
+  [/\bTITAN\s*V\b/i, 7.0],
+  // Pascal (6.0-6.1) - pre-Ampere
+  [/\bP100\b/i, 6.0],
+  [/\bP40\b/i, 6.1],
+  [/\bP4\b/i, 6.1],
+  [/\bGTX\s*10\d\d/i, 6.1],
+  // Maxwell (5.2) - pre-Ampere
+  [/\bM40\b/i, 5.2],
+  [/\bM60\b/i, 5.2],
+  // Kepler (3.5-3.7) - pre-Ampere
+  [/\bK80\b/i, 3.7],
+  [/\bK40\b/i, 3.5],
+]
+
+/**
+ * Get estimated CUDA compute capability from GPU name.
+ * Returns null if the GPU is not recognized.
+ */
+export function getGpuComputeCapability(gpuName: string): number | null {
+  for (const [pattern, cc] of GPU_COMPUTE_CAPABILITIES) {
+    if (pattern.test(gpuName)) {
+      return cc
+    }
+  }
+  return null
+}
+
+/**
+ * Check if a GPU needs an attention backend override because FlashInfer
+ * doesn't have kernel images for its compute capability.
+ * Returns true only for GPUs positively identified as pre-Ampere (CC < 8.0).
+ * Unknown GPUs return false (no override) to avoid false positives.
+ */
+export function needsAttentionBackendOverride(gpuName: string): boolean {
+  const cc = getGpuComputeCapability(gpuName)
+  return cc !== null && cc < MIN_FLASHINFER_COMPUTE_CAPABILITY
+}
+
 // Cached GPU info (singleton)
 let cachedGpuInfo: GpuInfo[] | null = null
 let initializationPromise: Promise<GpuInfo[]> | null = null

--- a/apps/frontend/src/chartTheme.ts
+++ b/apps/frontend/src/chartTheme.ts
@@ -1,0 +1,15 @@
+export const getNivoTooltipTheme = () => {
+  const isDark = document.documentElement.classList.contains('pf-v6-theme-dark')
+  return {
+    tooltip: {
+      container: {
+        background: isDark ? '#1f1f1f' : '#ffffff',
+        color: isDark ? '#e0e0e0' : '#151515',
+        padding: '8px 12px',
+        borderRadius: '4px',
+        border: isDark ? '1px solid #3c3f42' : '1px solid #d2d2d2',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.15)',
+      },
+    },
+  }
+}

--- a/apps/frontend/src/components/GpuMemoryPanel.tsx
+++ b/apps/frontend/src/components/GpuMemoryPanel.tsx
@@ -49,22 +49,7 @@ const SLEEPING_PATTERN_DEFS = [
   },
 ]
 
-// Nivo tooltip theme - detects PatternFly dark mode for proper styling
-const getTooltipTheme = () => {
-  const isDark = document.documentElement.classList.contains('pf-v6-theme-dark')
-  return {
-    tooltip: {
-      container: {
-        background: isDark ? '#1f1f1f' : '#ffffff',
-        color: isDark ? '#e0e0e0' : '#151515',
-        padding: '8px 12px',
-        borderRadius: '4px',
-        border: isDark ? '1px solid #3c3f42' : '1px solid #d2d2d2',
-        boxShadow: '0 2px 4px rgba(0,0,0,0.15)',
-      },
-    },
-  }
-}
+import { getNivoTooltipTheme } from '../chartTheme'
 
 const formatGb = (value: number) => `${value.toFixed(2)} GB`
 
@@ -180,7 +165,7 @@ function GpuCard({
           axisRight={null}
           axisBottom={null}
           axisLeft={null}
-          theme={getTooltipTheme()}
+          theme={getNivoTooltipTheme()}
           onClick={(bar) => {
             const model = gpu.models.find((m) => m.display_name === bar.id)
             if (model && onModelClick) {
@@ -275,7 +260,7 @@ function GpuCard({
               axisRight={null}
               axisBottom={null}
               axisLeft={null}
-              theme={getTooltipTheme()}
+              theme={getNivoTooltipTheme()}
             />
           </div>
           <Flex gap={{ default: 'gapSm' }} style={{ marginTop: '2px' }}>

--- a/apps/frontend/src/components/LoadModelDialog.tsx
+++ b/apps/frontend/src/components/LoadModelDialog.tsx
@@ -47,7 +47,7 @@ interface LoadModelDialogProps {
   /** Callback when dialog should close */
   onClose: () => void
   /** Callback to load a model. Must return the instance_id for SSE subscription */
-  onLoad: (request: LoadModelRequest) => Promise<{ instance_id: string }>
+  onLoad: (request: LoadModelRequest) => Promise<{ instance_id: string; warnings?: string[] }>
   /** Called after successful model load */
   onSuccess?: () => void
   /** Whether the cluster is in multi-pod mode */
@@ -114,6 +114,7 @@ export function LoadModelDialog({ isOpen, onClose, onLoad, onSuccess, isClusterM
   const [phase, setPhase] = useState<DialogPhase>('form')
   const [instanceId, setInstanceId] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [loadWarnings, setLoadWarnings] = useState<string[]>([])
 
   // SSE connection for live logs and progress - only active during loading phase
   const { isConnected, logs, progress, progressMessage, reconnect } = useInstanceEvents({
@@ -302,6 +303,7 @@ export function LoadModelDialog({ isOpen, onClose, onLoad, onSuccess, isClusterM
       }
 
       let resultInstanceId: string
+      let warnings: string[] = []
 
       if (isClusterMode && selectedPodId) {
         // Cluster mode: use cluster load API
@@ -315,11 +317,15 @@ export function LoadModelDialog({ isOpen, onClose, onLoad, onSuccess, isClusterM
           enableSleepMode: request.enable_sleep_mode,
         })
         resultInstanceId = clusterResult.instanceId
+        warnings = clusterResult.warnings ?? []
       } else {
         // Single-pod mode: use local load
         const result = await onLoad(request)
         resultInstanceId = result.instance_id
+        warnings = result.warnings ?? []
       }
+
+      setLoadWarnings(warnings)
 
       // Start listening for events from this instance
       setInstanceId(resultInstanceId)
@@ -355,6 +361,7 @@ export function LoadModelDialog({ isOpen, onClose, onLoad, onSuccess, isClusterM
     setLocalModelsBasePath('')
     setEnableSleepMode(true)
     setSelectedPodId(undefined)
+    setLoadWarnings([])
     onClose()
   }, [onClose])
 
@@ -888,6 +895,19 @@ export function LoadModelDialog({ isOpen, onClose, onLoad, onSuccess, isClusterM
 
         {(phase === 'loading' || phase === 'failed') && (
           <>
+            {loadWarnings.length > 0 && (
+              <Alert
+                variant="info"
+                isInline
+                title="Attention backend override"
+                style={{ marginBottom: 'var(--pf-t--global--spacer--md)' }}
+              >
+                {loadWarnings.map((w, i) => (
+                  <p key={i}>{w}</p>
+                ))}
+              </Alert>
+            )}
+
             <Progress
               aria-label="Model loading progress"
               value={phase === 'failed' ? 100 : (progress ?? undefined)}

--- a/apps/frontend/src/components/benchmark/BenchmarkResultsPanel.tsx
+++ b/apps/frontend/src/components/benchmark/BenchmarkResultsPanel.tsx
@@ -26,6 +26,7 @@ import {
 import { ExportIcon, RedoIcon } from '@patternfly/react-icons'
 import { ResponsiveBar } from '@nivo/bar'
 import { apiClient, extractErrorMessage, type BenchmarkSummary } from '../../services/api'
+import { getNivoTooltipTheme } from '../../chartTheme'
 
 interface BenchmarkResultsPanelProps {
   benchmarkId: string
@@ -339,6 +340,7 @@ export function BenchmarkResultsPanel({ benchmarkId, onRerun }: BenchmarkResults
                     padding={0.3}
                     groupMode="grouped"
                     colors={{ scheme: 'nivo' }}
+                    theme={getNivoTooltipTheme()}
                     axisBottom={{
                       tickSize: 5,
                       tickPadding: 5,
@@ -386,6 +388,7 @@ export function BenchmarkResultsPanel({ benchmarkId, onRerun }: BenchmarkResults
                     padding={0.3}
                     groupMode="grouped"
                     colors={{ scheme: 'nivo' }}
+                    theme={getNivoTooltipTheme()}
                     axisBottom={{
                       tickSize: 5,
                       tickPadding: 5,
@@ -433,6 +436,7 @@ export function BenchmarkResultsPanel({ benchmarkId, onRerun }: BenchmarkResults
                       margin={{ top: 20, right: 60, bottom: 50, left: 60 }}
                       padding={0.3}
                       colors={{ scheme: 'nivo' }}
+                      theme={getNivoTooltipTheme()}
                       valueScale={{ type: 'linear', max: 100 }}
                       axisBottom={{
                         tickSize: 5,

--- a/apps/frontend/src/pages/ModelManagement.tsx
+++ b/apps/frontend/src/pages/ModelManagement.tsx
@@ -218,7 +218,7 @@ function ModelManagement() {
 
   const handleLoadModel = async (request: LoadModelRequest) => {
     const result = await apiClient.loadModel(request)
-    return { instance_id: result.instance_id }
+    return { instance_id: result.instance_id, warnings: result.warnings }
   }
 
   const handleLoadSuccess = () => {

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -1296,6 +1296,7 @@ export interface ClusterLoadModelResponse {
   instanceId: string
   podId: string
   status: string
+  warnings?: string[]
 }
 
 export interface ClusterMoveModelRequest {

--- a/deployment/services.yaml
+++ b/deployment/services.yaml
@@ -29,6 +29,10 @@ metadata:
     app.kubernetes.io/part-of: sardeenz
 spec:
   type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 300
   selector:
     app: sardeenz
   ports:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -378,6 +378,13 @@ python -m vllm.entrypoints.openai.api_server \
 - `ENABLE_KVCACHED=true` - Enable kvcached memory sharing
 - `KVCACHED_AUTOPATCH=1` - Auto-patch vLLM for kvcached
 - `CUDA_VISIBLE_DEVICES=0` - GPU device assignment
+**Attention Backend Auto-Detection:**
+
+vLLM's default attention backend (FlashInfer) requires CUDA compute capability 8.0 or higher (Ampere architecture and newer). On pre-Ampere GPUs such as the T4 (compute capability 7.5) or V100 (7.0), FlashInfer kernels are not available and model loading will fail.
+
+The backend automatically detects GPU compute capability from NVML device names at launch time. When a target GPU is identified as pre-Ampere, `--attention-backend TRITON_ATTN` is appended to the vLLM CLI arguments, and a warning is surfaced in the load response and displayed in the dashboard's loading dialog.
+
+This override is skipped if the user has already specified `--attention-backend` in extra args.
 
 **Lifecycle States:**
 

--- a/docs/architecture/backend-architecture.md
+++ b/docs/architecture/backend-architecture.md
@@ -136,6 +136,39 @@ Intelligent GPU selection for model loading:
 - kvcached is automatically disabled for tensor parallel models
 - GPUs passed to vLLM via `CUDA_VISIBLE_DEVICES` environment variable
 
+### GPU Compute Capability Detection (`src/utils/gpu-info.ts`)
+
+Auto-detects GPU architecture to handle attention backend compatibility:
+
+- **Detection**: Maps NVML device names to CUDA compute capabilities via regex patterns
+- **Override trigger**: GPUs with compute capability < 8.0 (pre-Ampere) cannot run FlashInfer kernels
+- **Automatic fallback**: Appends `--attention-backend TRITON_ATTN` to the vLLM CLI arguments
+- **User feedback**: Populates `ModelInstance.warnings[]`, surfaced in the load response and dashboard UI
+
+**Key Functions:**
+
+- `getGpuComputeCapability(gpuName)` — Returns estimated compute capability from GPU name, or `null` if unrecognized
+- `needsAttentionBackendOverride(gpuName)` — Returns `true` only for GPUs positively identified as pre-Ampere (CC < 8.0); unknown GPUs return `false` to avoid false positives
+
+**Supported GPU Families:**
+
+| Architecture | Compute Capability | Examples | Needs Override |
+| --- | --- | --- | --- |
+| Blackwell | 10.0 | B100, B200 | No |
+| Hopper | 9.0 | H100, H200 | No |
+| Ada Lovelace | 8.9 | L4, L40/L40S, RTX 4090 | No |
+| Ampere | 8.0–8.6 | A100, A10G, RTX 3090 | No |
+| Turing | 7.5 | T4, RTX 2080 | Yes |
+| Volta | 7.0 | V100 | Yes |
+| Pascal | 6.0–6.1 | P100, P40, GTX 1080 | Yes |
+
+**Integration in `ModelManager.launchModel()`:**
+
+1. Reads cached GPU info from NVML (populated at startup)
+2. Checks target GPUs — skipped if user set `--attention-backend` in extra args
+3. If any target GPU is pre-Ampere, appends `--attention-backend TRITON_ATTN` to the vLLM CLI args and populates `instance.warnings`
+4. Warnings are returned in the load response (both single-pod and cluster paths) and displayed as an info banner in the loading dialog
+
 ### BenchmarkRunner (`src/services/benchmark-runner.ts`)
 
 Executes benchmark runs with real-time progress via SSE:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,7 @@ This guide covers container building and deployment to OpenShift/Kubernetes.
 | ---------------------------- | ------- | ------------------------ |
 | **Podman**                   | 4.x+    | Container runtime        |
 | **NVIDIA Container Toolkit** | 1.14.x+ | GPU access in containers |
-| **CUDA**                     | 12.x    | GPU compute              |
+| **CUDA**                     | 13.x    | GPU compute              |
 | **OpenShift** (optional)     | 4.12+   | Production orchestration |
 | **kubectl** (optional)       | 1.28+   | Kubernetes CLI           |
 
@@ -59,100 +59,105 @@ sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 **Verify GPU Access:**
 
 ```bash
-podman run --rm --device nvidia.com/gpu=all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi
+podman run --rm --device nvidia.com/gpu=all nvidia/cuda:13.0.0-base-ubi9 nvidia-smi
 ```
 
 ## Container Build
 
-### Dockerfile Structure
+### Image Overview
 
-The unified container image includes:
+The unified container image is built from `docker/Containerfile` as a multi-stage build:
 
-- **Base:** `quay.io/vllm/vllm-cuda:0.19.1_rhaiv.4` (CUDA 12.x + Python 3.12 + vLLM)
-- **Node.js 22.x** (added layer)
-- **Backend** (Fastify TypeScript app)
-- **Frontend** (React + PatternFly built static assets)
+| Stage | Base | Purpose |
+|-------|------|---------|
+| **0: vllm-base** | `quay.io/vllm/vllm-cuda:0.19.1_rhaiv.4` | CUDA 13.x + Python 3.12 + vLLM |
+| **1: kvcached-builder** | vllm-base + CUDA devel | Builds kvcached wheel from source |
+| **2: runtime-deps** | vllm-base + Node.js 22 | Production `npm ci --omit=dev` |
+| **3: builder** | runtime-deps + devDeps | Compiles TypeScript backend + Vite frontend |
+| **4: runtime** | runtime-deps + kvcached wheel | Final image with compiled dist only |
 
-### Build the Container
+The final image exposes port **3000** and runs `node apps/backend/dist/server.js` via `docker/entrypoint.sh`. Fastify serves both the API and the frontend static assets — no NGINX.
 
-**From project root:**
+**Registry:** `quay.io/rh-aiservices-bu/sardeenz`
+
+### Build and Push
 
 ```bash
-# Build and tag using Makefile (recommended)
-make build VERSION=x.y.z
-make push VERSION=x.y.z
+# Build and tag (recommended — uses Makefile)
+make build VERSION=0.8.0
+make push VERSION=0.8.0
 
-# Or manually with podman:
-podman build -f docker/Containerfile -t quay.io/rh-aiservices-bu/sardeenz:x.y.z .
-podman push quay.io/rh-aiservices-bu/sardeenz:x.y.z
+# Or both in one step
+make build-push VERSION=0.8.0
+
+# Or manually with podman
+podman build -f docker/Containerfile -t quay.io/rh-aiservices-bu/sardeenz:0.8.0 .
+podman push quay.io/rh-aiservices-bu/sardeenz:0.8.0
 ```
 
-**Build with custom vLLM version:**
+Run `make help` for a full list of targets and options.
+
+**Build with a different kvcached version:**
 
 ```bash
 podman build \
-  --build-arg VLLM_BASE_IMAGE=quay.io/vllm/vllm-cuda:0.19.1_rhaiv.4 \
+  --build-arg KVCACHED_VERSION=v0.1.6 \
   -f docker/Containerfile \
-  -t sardeenz:custom .
+  -t quay.io/rh-aiservices-bu/sardeenz:custom .
 ```
 
-### Multi-Stage Build Example
+### Release Workflow
 
-_Note: This is a conceptual Dockerfile structure. Actual implementation may vary._
+Sardeenz uses a single version in `package.json` at the project root (sub-packages are `private` and don't carry their own version). The release process is:
 
-```dockerfile
-# Stage 1: Build frontend
-FROM node:22-alpine AS frontend-builder
-WORKDIR /app
-COPY package*.json ./
-COPY apps/frontend/package*.json apps/frontend/
-RUN npm ci
-COPY apps/frontend apps/frontend
-COPY packages packages
-RUN npm run build -w apps/frontend
+**1. Update the version in `package.json`:**
 
-# Stage 2: Build backend
-FROM node:22-alpine AS backend-builder
-WORKDIR /app
-COPY package*.json ./
-COPY apps/backend/package*.json apps/backend/
-RUN npm ci --production
-COPY apps/backend apps/backend
-COPY packages packages
-RUN npm run build -w apps/backend
+```bash
+# Minor bump (default — e.g., 0.7.0 → 0.8.0)
+npm version minor --no-git-tag-version
 
-# Stage 3: Final image
-FROM quay.io/vllm/vllm-cuda:0.19.1_rhaiv.4
-
-# Install Node.js 22
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g npm@latest
-
-# Install kvcached
-RUN pip install kvcached
-
-# Copy built artifacts
-WORKDIR /app
-COPY --from=backend-builder /app/apps/backend/dist ./backend
-COPY --from=backend-builder /app/node_modules ./node_modules
-COPY --from=frontend-builder /app/apps/frontend/dist ./frontend
-
-# Expose port (unified API - Controller + Proxy + Frontend)
-EXPOSE 3000
-
-# Set environment variables
-ENV NODE_ENV=production
-ENV ENABLE_KVCACHED=true
-ENV KVCACHED_AUTOPATCH=1
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
-  CMD curl -f http://localhost:3000/api/health || exit 1
-
-# Start command
-CMD ["node", "backend/index.js"]
+# Or patch bump for hotfixes (e.g., 0.7.0 → 0.7.1)
+npm version patch --no-git-tag-version
 ```
+
+**2. Update `CHANGELOG.md`:**
+
+Add a new section at the top of the file, following the existing format:
+
+```markdown
+## [0.8.0] - 2026-06-05
+
+### Section Title
+
+- **Feature name**: Description of what was added or changed
+  - Sub-bullets for implementation details
+```
+
+If you use Claude Code, the `/generate-changelog` skill generates changelog entries automatically from the commits between `dev` and `main`.
+
+**3. Commit, merge to main, build, and push:**
+
+```bash
+git add package.json package-lock.json CHANGELOG.md
+git commit -m "release: v0.8.0"
+# Merge to main via PR, then:
+make build-push VERSION=0.8.0
+```
+
+**4. Update the deployment:**
+
+Update the image tag in `deployment/statefulset.yaml` (or use `oc set image`) and re-apply:
+
+```bash
+oc set image statefulset/sardeenz sardeenz=quay.io/rh-aiservices-bu/sardeenz:0.8.0
+```
+
+### Version Conventions
+
+- **Minor bumps** (0.7.0 → 0.8.0) are the default for all releases
+- **Patch bumps** (0.7.0 → 0.7.1) are for hotfixes only
+- The container image tag matches the version in `package.json`
+- There is no automated CI pipeline for image builds — builds are triggered manually via `make build-push`
 
 ## Local Development
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -6,7 +6,7 @@ This guide covers setting up a local development environment with NVIDIA GPU sup
 
 ### Hardware
 
-- NVIDIA GPU with CUDA 12.x drivers
+- NVIDIA GPU with CUDA 13.x drivers
 - 8GB+ VRAM (16GB+ recommended for larger models)
 
 ### Software
@@ -22,7 +22,7 @@ This guide covers setting up a local development environment with NVIDIA GPU sup
 nvidia-smi
 
 # Expected output shows GPU name, driver version, CUDA version
-# Example: NVIDIA GeForce RTX 3070, Driver 535.xx, CUDA 12.x
+# Example: NVIDIA GeForce RTX 3070, Driver 565.xx, CUDA 13.x
 ```
 
 ### Install uv (Python Package Manager)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,7 +6,7 @@ This guide covers setting up a local development environment for contributing to
 
 - **Node.js 22.x** with npm 10.x+
 - **Python 3.12** + [uv](https://docs.astral.sh/uv/) (for vLLM)
-- **NVIDIA GPU** with CUDA 12.x and 8GB+ VRAM (16GB+ recommended for multiple models)
+- **NVIDIA GPU** with CUDA 13.x and 8GB+ VRAM (16GB+ recommended for multiple models)
 
 ## Quick Start
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -316,6 +316,12 @@ Authentication mode is configured by the deployment (`AUTH_MODE` environment var
 - **Leader changed notification** — Normal during failover. The dashboard automatically redirects to the new leader
 - **Pod selector shows a pod as unavailable** — The pod may be restarting or disconnected from the cluster
 
+### "Attention backend override" info banner during model load
+
+When loading a model, you may see an info banner saying the GPU does not support the FlashInfer attention backend and that TRITON_ATTN is being used instead. This happens automatically on pre-Ampere GPUs (e.g., T4, V100, P100) where FlashInfer kernels are not available. No action is needed — the model will load and run correctly with the alternative backend. Performance is comparable for most workloads.
+
+If you want to control the attention backend yourself, add `--attention-backend <value>` in the **Extra vLLM Arguments** field when loading a model.
+
 ### GPU Info shows no data
 
 - Ensure the NVIDIA drivers are installed and nvidia-smi works on the host

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sardeenz",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sardeenz",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sardeenz",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Multi-model vLLM management platform with dynamic loading and unified inference proxy",
   "private": true,
   "type": "module",

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -22,6 +22,7 @@ export interface LoadModelResponse {
   port: number
   loaded_at: string
   instance_id: string
+  warnings?: string[]
 }
 
 export interface UnloadModelResponse {

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -100,6 +100,8 @@ export interface ModelInstance {
   routable: boolean
   /** Pod ID when running in a cluster (hostname from StatefulSet) */
   podId?: string
+  /** Warnings generated during model launch (e.g., attention backend overrides) */
+  warnings?: string[]
 }
 
 /** Phase of a model move operation */

--- a/packages/types/src/validation.ts
+++ b/packages/types/src/validation.ts
@@ -71,6 +71,7 @@ export const LoadModelResponseSchema = Type.Object({
   port: Type.Integer(),
   loaded_at: Type.String({ format: 'date-time' }),
   instance_id: Type.String({ format: 'uuid' }),
+  warnings: Type.Optional(Type.Array(Type.String())),
 })
 
 export const UnloadModelResponseSchema = Type.Object({


### PR DESCRIPTION
## [0.7.1] - 2026-06-09

### Bug Fixes

- **OAuth state in cluster mode**: Moved OAuth state storage from in-memory Map to PostgreSQL, fixing login failures when OAuth callbacks land on a different pod than the one that initiated the flow
- **Pre-Ampere GPU support**: Auto-detect GPUs with compute capability < 8.0 (T4, V100, P100, etc.) and override the attention backend to TRITON_ATTN via the `--attention-backend` CLI argument, since FlashInfer kernels are not available on these architectures
- **Leader-redirect OAuth hostname**: Preserve the external hostname when leader-redirect forwards OAuth login requests, preventing redirect URI mismatches
- **Leader-redirect URL fragments**: Prevent leader-redirect from following redirects and dropping URL hash fragments
- **Dashboard background colors**: Fixed background color inconsistencies in the frontend