### PR TITLE
fix: rename VLLM_* env vars to SARDEENZ_VLLM_* to avoid vLLM namespace collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Sardeenz is a multi-model management application that enables dynamic loading an
 
 ## Quick Start
 
+> ### ⚠️ Breaking change — environment variables renamed
+>
+> **Upgrading from v0.7.x or earlier?** Three env vars were renamed from the `VLLM_` prefix to `SARDEENZ_` (the old names collided with vLLM's own namespace). The old names are **no longer read** — update them before deploying or Sardeenz falls back to defaults:
+>
+> | Old name (remove) | New name (use) |
+> | --- | --- |
+> | `VLLM_BASE_PORT` | `SARDEENZ_VLLM_BASE_PORT` |
+> | `VLLM_MAX_INSTANCES` | `SARDEENZ_VLLM_MAX_INSTANCES` |
+> | `VLLM_STARTUP_TIMEOUT` | `SARDEENZ_VLLM_STARTUP_TIMEOUT` |
+>
+> See the [Deployment Guide](./docs/deployment.md) for details.
+
 Pre-built container images are available at `quay.io/rh-aiservices-bu/sardeenz`.
 
 **Run locally with Docker:**

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -44,10 +44,10 @@ INFERENCE_API_KEY=
 # vLLM configuration
 # In cluster mode with CLUSTER_PEERS, this is auto-offset per pod (stride=100)
 # to avoid port collisions on localhost. Set explicitly to override.
-VLLM_BASE_PORT=12346
-VLLM_MAX_INSTANCES=10
+SARDEENZ_VLLM_BASE_PORT=12346
+SARDEENZ_VLLM_MAX_INSTANCES=10
 # Model startup timeout in ms (default 30 min, increase for slow downloads)
-VLLM_STARTUP_TIMEOUT=1800000
+SARDEENZ_VLLM_STARTUP_TIMEOUT=1800000
 
 # kvcached configuration
 ENABLE_KVCACHED=true

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -110,8 +110,8 @@ See `apps/backend/.env.example` for a complete reference.
 | Variable               | Default                   | Description                                                                                  |
 | ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------- |
 | `PORT`                 | 3000                      | Backend server port                                                                          |
-| `VLLM_BASE_PORT`       | 12346                     | Base port for vLLM instances (auto-offset per pod in cluster mode)                           |
-| `VLLM_STARTUP_TIMEOUT` | 1800000                   | Model startup timeout in ms (30 min default)                                                 |
+| `SARDEENZ_VLLM_BASE_PORT`       | 12346            | Base port for vLLM instances (auto-offset per pod in cluster mode)                           |
+| `SARDEENZ_VLLM_STARTUP_TIMEOUT` | 1800000          | Model startup timeout in ms (30 min default)                                                 |
 | `ENABLE_KVCACHED`      | true                      | Enable kvcached GPU sharing                                                                  |
 | `KVCACHED_AUTOPATCH`   | 1                         | Auto-patch vLLM for kvcached                                                                 |
 | `LOG_LEVEL`            | info                      | Pino log level                                                                               |

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -147,10 +147,10 @@ export const config: Config = {
   // vLLM configuration
   // In cluster mode with CLUSTER_PEERS, auto-offset by pod index * 100 to avoid
   // port collisions when multiple pods share the same host (local dev).
-  // Explicit VLLM_BASE_PORT always takes precedence.
+  // Explicit SARDEENZ_VLLM_BASE_PORT always takes precedence.
   vllmBasePort: (() => {
     const STRIDE = 100
-    const base = getEnvInt('VLLM_BASE_PORT', 12346)
+    const base = getEnvInt('SARDEENZ_VLLM_BASE_PORT', 12346)
     const peers = getEnv('CLUSTER_PEERS', '')
     if (!peers) return base
     const peerList = peers.split(',').map((p) => p.trim())
@@ -161,8 +161,8 @@ export const config: Config = {
     })
     return base + Math.max(podIndex, 0) * STRIDE
   })(),
-  vllmMaxInstances: getEnvInt('VLLM_MAX_INSTANCES', 10),
-  vllmStartupTimeout: getEnvInt('VLLM_STARTUP_TIMEOUT', 1800000), // 30 minutes default
+  vllmMaxInstances: getEnvInt('SARDEENZ_VLLM_MAX_INSTANCES', 10),
+  vllmStartupTimeout: getEnvInt('SARDEENZ_VLLM_STARTUP_TIMEOUT', 1800000), // 30 minutes default
 
   // kvcached configuration
   enableKvcached: getEnvBool('ENABLE_KVCACHED', true),

--- a/apps/backend/src/services/model-manager.ts
+++ b/apps/backend/src/services/model-manager.ts
@@ -488,7 +488,7 @@ export class ModelManager extends EventEmitter {
     }
 
     try {
-      // Wait for model to be ready (configurable via VLLM_STARTUP_TIMEOUT)
+      // Wait for model to be ready (configurable via SARDEENZ_VLLM_STARTUP_TIMEOUT)
       await this.waitForReady(port, modelPath, config.vllmStartupTimeout)
 
       // Emit final progress event for ready state

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -203,9 +203,9 @@ oc get route sardeenz -n sardeenz -o jsonpath='{.spec.host}'
 | `API_BASE_URL`         | -            | Base URL for OAuth callbacks (your route URL)                                                                                                                  |
 | `ENABLE_KVCACHED`      | `true`       | Enable kvcached GPU memory sharing                                                                                                                             |
 | `KVCACHED_AUTOPATCH`   | `1`          | Auto-patch vLLM for kvcached                                                                                                                                   |
-| `VLLM_BASE_PORT`       | `12346`      | Starting port for vLLM instances                                                                                                                               |
-| `VLLM_MAX_INSTANCES`   | `10`         | Maximum concurrent model instances                                                                                                                             |
-| `VLLM_STARTUP_TIMEOUT` | `1800000`    | Model startup timeout in ms (30 min default)                                                                                                                   |
+| `SARDEENZ_VLLM_BASE_PORT`       | `12346`      | Starting port for vLLM instances                                                                                                                      |
+| `SARDEENZ_VLLM_MAX_INSTANCES`   | `10`         | Maximum concurrent model instances                                                                                                                    |
+| `SARDEENZ_VLLM_STARTUP_TIMEOUT` | `1800000`    | Model startup timeout in ms (30 min default)                                                                                                          |
 | `LOCAL_MODELS_PATH`    | -            | Path to pre-downloaded models. Set this when using local/mounted models instead of HuggingFace downloads. See [Storage Configuration](#storage-configuration). |
 | `DEBUG_STREAMING`      | `false`      | Enable SSE streaming debug logs                                                                                                                                |
 
@@ -651,8 +651,8 @@ oc logs -f statefulset/sardeenz
 **Common causes:**
 
 - vLLM taking too long to start → Increase `startupProbe.failureThreshold`
-- Out of GPU memory → Reduce model size or adjust `VLLM_MAX_INSTANCES`
-- Port conflicts → Check `VLLM_BASE_PORT` configuration
+- Out of GPU memory → Reduce model size or adjust `SARDEENZ_VLLM_MAX_INSTANCES`
+- Port conflicts → Check `SARDEENZ_VLLM_BASE_PORT` configuration
 
 ### Model Loading Failures
 
@@ -681,7 +681,7 @@ oc adm top pod -l app=sardeenz
 - Increase CPU/memory limits in `statefulset.yaml`
 - Enable kvcached for better GPU memory sharing
 - Use faster storage class for PVC
-- Adjust `VLLM_MAX_INSTANCES` based on available GPU memory
+- Adjust `SARDEENZ_VLLM_MAX_INSTANCES` based on available GPU memory
 
 ## Upgrading
 

--- a/deployment/configmap.yaml
+++ b/deployment/configmap.yaml
@@ -45,12 +45,12 @@ data:
   # =============================================================================
   # vLLM Instance Configuration
   # =============================================================================
-  VLLM_BASE_PORT: "12346"
-  VLLM_MAX_INSTANCES: "10"
+  SARDEENZ_VLLM_BASE_PORT: "12346"
+  SARDEENZ_VLLM_MAX_INSTANCES: "10"
 
   # Model startup timeout in ms (default 30 min)
   # Increase for slow network connections or very large models
-  VLLM_STARTUP_TIMEOUT: "1800000"
+  SARDEENZ_VLLM_STARTUP_TIMEOUT: "1800000"
 
   # =============================================================================
   # Optional Features

--- a/deployment/statefulset.yaml
+++ b/deployment/statefulset.yaml
@@ -201,21 +201,21 @@ spec:
             # =================================================================
             # vLLM Configuration (from ConfigMap)
             # =================================================================
-            - name: VLLM_BASE_PORT
+            - name: SARDEENZ_VLLM_BASE_PORT
               valueFrom:
                 configMapKeyRef:
                   name: sardeenz-config
-                  key: VLLM_BASE_PORT
-            - name: VLLM_MAX_INSTANCES
+                  key: SARDEENZ_VLLM_BASE_PORT
+            - name: SARDEENZ_VLLM_MAX_INSTANCES
               valueFrom:
                 configMapKeyRef:
                   name: sardeenz-config
-                  key: VLLM_MAX_INSTANCES
-            - name: VLLM_STARTUP_TIMEOUT
+                  key: SARDEENZ_VLLM_MAX_INSTANCES
+            - name: SARDEENZ_VLLM_STARTUP_TIMEOUT
               valueFrom:
                 configMapKeyRef:
                   name: sardeenz-config
-                  key: VLLM_STARTUP_TIMEOUT
+                  key: SARDEENZ_VLLM_STARTUP_TIMEOUT
 
             # =================================================================
             # Optional Features (from ConfigMap)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - LOG_LEVEL=info
       - ENABLE_KVCACHED=true
       - KVCACHED_AUTOPATCH=1
-      - VLLM_BASE_PORT=12346
-      - VLLM_MAX_INSTANCES=10
+      - SARDEENZ_VLLM_BASE_PORT=12346
+      - SARDEENZ_VLLM_MAX_INSTANCES=10
       - DATABASE_URL=postgresql://sardeenz:sardeenz@postgresql:5432/sardeenz
     volumes:
       - ~/.cache/huggingface:/root/.cache/huggingface

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,7 +297,7 @@ Sardeenz supports multi-pod deployment where multiple instances coordinate to di
 | `CLUSTER_SECRET` | `''` | Shared HMAC-SHA256 secret for inter-pod authentication |
 | `CLUSTER_EXPECTED_PODS` | `0` | Expected cluster size (for quorum calculation before all pods visible) |
 | `NAMESPACE` | `'sardeenz'` | Kubernetes namespace for peer discovery and lease |
-| `VLLM_BASE_PORT` | `12346` | Base port for vLLM instances (auto-offset per pod in cluster mode) |
+| `SARDEENZ_VLLM_BASE_PORT` | `12346` | Base port for vLLM instances (auto-offset per pod in cluster mode) |
 
 ### Core Cluster Services
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,20 @@
 
 This guide covers container building and deployment to OpenShift/Kubernetes.
 
+> ## ⚠️ Breaking change — environment variables renamed
+>
+> **If you are upgrading from v0.7.x or earlier, you must update your configuration before deploying.**
+>
+> Three environment variables have been renamed to use the `SARDEENZ_` prefix (they were previously prefixed with `VLLM_`, which collided with vLLM's own namespace and produced spurious warnings). The **old names are no longer read** — if you leave them set, Sardeenz silently falls back to defaults.
+>
+> | Old name (remove) | New name (use) |
+> | --- | --- |
+> | `VLLM_BASE_PORT` | `SARDEENZ_VLLM_BASE_PORT` |
+> | `VLLM_MAX_INSTANCES` | `SARDEENZ_VLLM_MAX_INSTANCES` |
+> | `VLLM_STARTUP_TIMEOUT` | `SARDEENZ_VLLM_STARTUP_TIMEOUT` |
+>
+> Update these in your ConfigMap / `.env` / `docker run -e` flags. The manifests in [`deployment/`](../deployment/) already use the new names.
+
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -298,7 +298,7 @@ This launches multiple backend instances on sequential ports (3001, 3002, ...) p
 | 1   | 3002     | 12446–12545     |
 | 2   | 3003     | 12546–12645     |
 
-This is automatic when `CLUSTER_PEERS` is set and `VLLM_BASE_PORT` is not explicitly configured. Set `VLLM_BASE_PORT` to override.
+This is automatic when `CLUSTER_PEERS` is set and `SARDEENZ_VLLM_BASE_PORT` is not explicitly configured. Set `SARDEENZ_VLLM_BASE_PORT` to override.
 
 ### Frontend-Only Development
 

--- a/specs/001-multi-model-platform/quickstart.md
+++ b/specs/001-multi-model-platform/quickstart.md
@@ -231,8 +231,8 @@ JWT_SECRET=change-me-in-production
 API_BASE_URL=http://localhost:3000
 
 # vLLM Configuration
-VLLM_BASE_PORT=12346
-VLLM_MAX_INSTANCES=10
+SARDEENZ_VLLM_BASE_PORT=12346
+SARDEENZ_VLLM_MAX_INSTANCES=10
 
 # kvcached Configuration
 ENABLE_KVCACHED=true

--- a/specs/006-inference-sim-backend/quickstart.md
+++ b/specs/006-inference-sim-backend/quickstart.md
@@ -67,7 +67,7 @@ npm run dev -w apps/backend
 
 Open the dashboard pointing at either pod. Load models, verify cross-pod routing, test model moves.
 
-> **Port ranges**: vLLM serving ports are automatically partitioned per pod (stride of 100) to avoid collisions on localhost. Pod A uses ports 12346–12445, Pod B uses 12446–12545, etc. Set `VLLM_BASE_PORT` explicitly to override.
+> **Port ranges**: vLLM serving ports are automatically partitioned per pod (stride of 100) to avoid collisions on localhost. Pod A uses ports 12346–12445, Pod B uses 12446–12545, etc. Set `SARDEENZ_VLLM_BASE_PORT` explicitly to override.
 
 ## Configuration Reference
 


### PR DESCRIPTION
## Summary

Closes #43.

Sardeenz defined three env vars prefixed with `VLLM_` that vLLM does **not** recognize. vLLM validates all `VLLM_`-prefixed vars against its internal registry and emits `Unknown vLLM environment variable` warnings for each on every model load — noisy logs, plus a future collision risk if vLLM ever introduces vars of the same name.

These are renamed to the `SARDEENZ_` prefix (consistent with the existing `SARDEENZ_INSTANCE_ID`):

| Old | New |
| --- | --- |
| `VLLM_BASE_PORT` | `SARDEENZ_VLLM_BASE_PORT` |
| `VLLM_MAX_INSTANCES` | `SARDEENZ_VLLM_MAX_INSTANCES` |
| `VLLM_STARTUP_TIMEOUT` | `SARDEENZ_VLLM_STARTUP_TIMEOUT` |

## ⚠️ Breaking change

The old names are **no longer read** — upgraders from v0.7.x or earlier must update their ConfigMap / `.env` / `docker run -e` flags, or Sardeenz falls back to defaults. The in-repo manifests already use the new names. A prominent notice was added to the top of the main README (Quick Start) and the Deployment Guide.

## Changes

- **Code:** `apps/backend/src/config.ts`, `apps/backend/src/services/model-manager.ts`
- **Config/manifests:** `apps/backend/.env.example`, `deployment/configmap.yaml`, `deployment/statefulset.yaml`, `docker/docker-compose.yml`
- **Docs:** `README.md`, `docs/deployment.md`, `deployment/README.md`, `docs/architecture.md`, `docs/dev-setup.md`, `apps/backend/CLAUDE.md`, `specs/001-multi-model-platform/quickstart.md`, `specs/006-inference-sim-backend/quickstart.md`

Discovery turned up references beyond the five files listed in the issue (docker-compose, dev-setup, architecture, both spec quickstarts); all were updated so no stale references remain.

## Verification

- Post-change search: no old `VLLM_*` references remain
- `tsc --noEmit`: clean
- ESLint: clean (2 pre-existing `any` warnings in an unrelated file)
- 148/148 backend tests pass