### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-12
+
+### Helm Chart Deployment
+
+- **Helm chart** replaces the raw Kustomize manifests as the supported deployment path (`deploy/helm/sardeenz/`). The chart is published as an OCI artifact, so it can be installed directly from the registry without cloning the repo:
+  ```bash
+  helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart \
+    --version 0.8.0 --namespace sardeenz --create-namespace
+  ```
+- **Full stack in one release**: templates for the application StatefulSet (GPU-scheduled), ConfigMap, Secret, model-cache PVC, Services (headless + ClusterIP), OpenShift Route, conditional RBAC, and an optional bundled PostgreSQL
+- **Kubernetes Ingress** support as an alternative to the OpenShift Route (`ingress.enabled`)
+- **Single source of truth for scaling**: `replicaCount` drives both the StatefulSet replicas and `CLUSTER_EXPECTED_PODS`
+- **Conditional RBAC**: OAuth auth-reviewer roles render only when `auth.mode=oauth`; cluster-coordination roles only when `replicaCount > 1`
+- **Production-friendly secrets**: `secrets.existingSecret` references a pre-created Secret so credentials never live in values; the bundled database password is auto-generated and preserved across upgrades
+- **`values.schema.json`** validates configuration at install time, and `helm test` verifies a release against `/api/health/ready`
+- **Makefile targets**: `helm-lint`, `helm-template`, `helm-package`, `helm-push`, and `helm-package-push`, with the chart version sourced from `package.json` to stay in lockstep with the application
+- Fixed a latent OpenShift Route bug carried over from the manifests: `targetPort` pointed at a nonexistent `backend` port and is now `http`
+- The Kustomize manifests under `deployment/` are **deprecated** and will be removed in a future release
+
+### Breaking Changes
+
+- **Deployment mechanism changed to Helm**: existing Kustomize-based deployments should migrate to the chart. See [`deploy/helm/sardeenz/README.md`](deploy/helm/sardeenz/README.md) and [`docs/deployment.md`](docs/deployment.md)
+- **vLLM environment variables renamed** to the `SARDEENZ_VLLM_*` prefix to avoid colliding with vLLM's own namespace. The old names are no longer read — update your configuration before upgrading:
+
+  | Old name (remove) | New name (use) |
+  | --- | --- |
+  | `VLLM_BASE_PORT` | `SARDEENZ_VLLM_BASE_PORT` |
+  | `VLLM_MAX_INSTANCES` | `SARDEENZ_VLLM_MAX_INSTANCES` |
+  | `VLLM_STARTUP_TIMEOUT` | `SARDEENZ_VLLM_STARTUP_TIMEOUT` |
+
 ## [0.7.1] - 2026-06-09
 
 ### Bug Fixes

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,20 @@ VERSION ?= latest
 # Full image tag
 IMAGE_TAG := $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(VERSION)
 
+# Helm chart configuration
+CHART_DIR := deploy/helm/sardeenz
+# Chart name from Chart.yaml — also the packaged .tgz prefix and OCI repo name.
+CHART_NAME := sardeenz-chart
+# OCI push target (the org). `helm push` appends the chart name (sardeenz-chart),
+# so the artifact lands at quay.io/rh-aiservices-bu/sardeenz-chart:<version>.
+CHART_OCI_REPO := oci://$(IMAGE_REGISTRY)
+# Directory packaged .tgz artifacts are written to
+CHART_PACKAGE_DIR := dist/charts
+# Chart/app version — sourced from package.json so the chart stays in lockstep
+# with the application (override with `make helm-package VERSION=x.y.z`).
+APP_VERSION := $(shell node -p "require('./package.json').version" 2>/dev/null || echo 0.0.0)
+CHART_VERSION ?= $(APP_VERSION)
+
 # Cluster simulator defaults (override with make dev\:cluster\:sim PODS=3 GPUS=4)
 PODS ?= 2
 GPUS ?= 2
@@ -18,7 +32,8 @@ SIM_GPU_MEMORY ?= 24
 SIM_STARTUP ?= 3s
 BASE_PORT ?= 3001
 
-.PHONY: build push help dev\:cluster\:sim
+.PHONY: build push help dev\:cluster\:sim \
+	helm-lint helm-template helm-package helm-push helm-package-push
 
 ## build: Build the container image (usage: make build VERSION=x.y.z)
 build:
@@ -35,6 +50,33 @@ push:
 
 ## build-push: Build and push in one step
 build-push: build push
+
+## helm-lint: Lint the Helm chart
+helm-lint:
+	helm lint $(CHART_DIR)
+
+## helm-template: Render the chart to stdout (usage: make helm-template [ARGS="--set ..."])
+helm-template:
+	helm template sardeenz $(CHART_DIR) $(ARGS)
+
+## helm-package: Package the chart as <name>-<version>.tgz (version from package.json)
+helm-package: helm-lint
+	@mkdir -p $(CHART_PACKAGE_DIR)
+	helm package $(CHART_DIR) \
+		--version $(CHART_VERSION) \
+		--app-version $(CHART_VERSION) \
+		--destination $(CHART_PACKAGE_DIR)
+	@echo "Packaged: $(CHART_PACKAGE_DIR)/$(CHART_NAME)-$(CHART_VERSION).tgz"
+
+## helm-push: Push the packaged chart to the OCI registry (run helm-package first)
+##   Lands at quay.io/rh-aiservices-bu/sardeenz-chart:<version>
+##   Requires: helm registry login quay.io
+helm-push:
+	helm push $(CHART_PACKAGE_DIR)/$(CHART_NAME)-$(CHART_VERSION).tgz $(CHART_OCI_REPO)
+	@echo "Pushed: $(IMAGE_REGISTRY)/$(CHART_NAME):$(CHART_VERSION)"
+
+## helm-package-push: Package and push the chart in one step
+helm-package-push: helm-package helm-push
 
 ## dev:cluster:sim: Launch a simulated multi-pod cluster (GPU-free)
 ##   Usage: make dev:cluster:sim [PODS=2] [GPUS=2] [SIM_GPU_MEMORY=24] [BASE_PORT=3001]
@@ -70,6 +112,13 @@ help:
 	@echo "  make build VERSION=x.y.z       Build container image"
 	@echo "  make push VERSION=x.y.z        Push to quay.io"
 	@echo "  make build-push VERSION=x.y.z  Build and push"
+	@echo ""
+	@echo "Helm chart (version from package.json: $(APP_VERSION)):"
+	@echo "  make helm-lint                 Lint the chart"
+	@echo "  make helm-template [ARGS=...]  Render manifests to stdout"
+	@echo "  make helm-package              Package chart -> $(CHART_PACKAGE_DIR)/"
+	@echo "  make helm-push                 Push chart to $(IMAGE_REGISTRY)/$(CHART_NAME)"
+	@echo "  make helm-package-push         Package and push"
 	@echo ""
 	@echo "Development:"
 	@echo "  make dev:cluster:sim           Launch 2-pod simulated cluster (GPU-free)"

--- a/deploy/helm/sardeenz/.helmignore
+++ b/deploy/helm/sardeenz/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+*.tmp
+*.bak
+*.swp
+.DS_Store
+.git/
+.gitignore
+*.tgz

--- a/deploy/helm/sardeenz/Chart.yaml
+++ b/deploy/helm/sardeenz/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+# Chart is named `sardeenz-chart` so that `helm push` lands the OCI artifact at
+# quay.io/rh-aiservices-bu/sardeenz-chart (separate from the image repo). The
+# rendered Kubernetes resources are still named `sardeenz` via nameOverride.
+name: sardeenz-chart
+description: Multi-model LLM management platform — dynamic loading, serving, and cluster orchestration on top of vLLM + kvcached
+type: application
+home: https://github.com/rh-aiservices-bu/sardeenz
+sources:
+  - https://github.com/rh-aiservices-bu/sardeenz
+keywords:
+  - llm
+  - vllm
+  - kvcached
+  - inference
+  - openshift
+  - gpu
+maintainers:
+  - name: Red Hat AI Services BU
+    url: https://github.com/rh-aiservices-bu
+# Chart version is kept in lockstep with the application version.
+# Bump both together at release time.
+version: 0.7.1
+appVersion: "0.7.1"

--- a/deploy/helm/sardeenz/Chart.yaml
+++ b/deploy/helm/sardeenz/Chart.yaml
@@ -20,5 +20,5 @@ maintainers:
     url: https://github.com/rh-aiservices-bu
 # Chart version is kept in lockstep with the application version.
 # Bump both together at release time.
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.8.0
+appVersion: "0.8.0"

--- a/deploy/helm/sardeenz/README.md
+++ b/deploy/helm/sardeenz/README.md
@@ -15,7 +15,7 @@ The chart is published as an OCI artifact alongside the container image:
 # Single-pod, no auth, bundled PostgreSQL — a working quick start
 helm install sardeenz \
   oci://quay.io/rh-aiservices-bu/sardeenz-chart \
-  --version 0.7.1 \
+  --version 0.8.0 \
   --namespace sardeenz --create-namespace
 ```
 
@@ -27,7 +27,7 @@ helm install sardeenz \
 ### Simple username/password auth
 
 ```bash
-helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.8.0 \
   -n sardeenz --create-namespace \
   --set auth.mode=simple \
   --set auth.adminPassword='<password>' \
@@ -37,7 +37,7 @@ helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.
 ### OpenShift OAuth
 
 ```bash
-helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.8.0 \
   -n sardeenz --create-namespace \
   --set auth.mode=oauth \
   --set auth.oauth.clientId=<id> \
@@ -54,7 +54,7 @@ OAuth also renders the auth-reviewer RBAC. Bind users to the `sardeenz-admin` /
 ### Multi-pod cluster
 
 ```bash
-helm upgrade --install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+helm upgrade --install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.8.0 \
   -n sardeenz \
   --set replicaCount=3 \
   --set cluster.secret="$(openssl rand -hex 32)"
@@ -76,7 +76,7 @@ oc create secret generic sardeenz-secrets -n sardeenz \
   --from-literal=db-password="$(openssl rand -base64 16)" \
   --from-literal=database-url='postgresql://sardeenz:<password>@sardeenz-postgresql:5432/sardeenz'
 
-helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.8.0 \
   -n sardeenz --set secrets.existingSecret=sardeenz-secrets
 ```
 

--- a/deploy/helm/sardeenz/README.md
+++ b/deploy/helm/sardeenz/README.md
@@ -1,0 +1,140 @@
+# sardeenz Helm chart
+
+Deploys [sardeenz](https://github.com/rh-aiservices-bu/sardeenz) — a multi-model
+LLM management platform built on vLLM + kvcached — to OpenShift or Kubernetes.
+
+The chart provisions the application StatefulSet (GPU-scheduled), a ConfigMap and
+Secret, the model-cache PVC, Services (headless + ClusterIP), an OpenShift Route
+(or Kubernetes Ingress), conditional RBAC, and an optional bundled PostgreSQL.
+
+## Install from the chart registry (no clone required)
+
+The chart is published as an OCI artifact alongside the container image:
+
+```bash
+# Single-pod, no auth, bundled PostgreSQL — a working quick start
+helm install sardeenz \
+  oci://quay.io/rh-aiservices-bu/sardeenz-chart \
+  --version 0.7.1 \
+  --namespace sardeenz --create-namespace
+```
+
+> The chart version tracks the application version. Pick the `--version` that
+> matches the sardeenz release you want to run.
+
+## Common configurations
+
+### Simple username/password auth
+
+```bash
+helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+  -n sardeenz --create-namespace \
+  --set auth.mode=simple \
+  --set auth.adminPassword='<password>' \
+  --set auth.jwtSecret="$(openssl rand -base64 32)"
+```
+
+### OpenShift OAuth
+
+```bash
+helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+  -n sardeenz --create-namespace \
+  --set auth.mode=oauth \
+  --set auth.oauth.clientId=<id> \
+  --set auth.oauth.clientSecret=<secret> \
+  --set auth.oauth.issuerUrl=https://oauth-openshift.apps.<cluster> \
+  --set auth.oauth.k8sApiUrl=https://api.<cluster>:6443 \
+  --set auth.jwtSecret="$(openssl rand -base64 32)" \
+  --set auth.apiBaseUrl=https://sardeenz.apps.<cluster>
+```
+
+OAuth also renders the auth-reviewer RBAC. Bind users to the `sardeenz-admin` /
+`sardeenz-admin-readonly` roles separately — see `docs/rbac-setup.md`.
+
+### Multi-pod cluster
+
+```bash
+helm upgrade --install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+  -n sardeenz \
+  --set replicaCount=3 \
+  --set cluster.secret="$(openssl rand -hex 32)"
+```
+
+`replicaCount` drives both the StatefulSet replicas and `CLUSTER_EXPECTED_PODS`,
+and renders the cluster-coordination RBAC (pod discovery + leader-election leases).
+
+### Production secrets (recommended)
+
+Avoid putting secrets in `--set`/values. Pre-create the Secret and reference it:
+
+```bash
+oc create secret generic sardeenz-secrets -n sardeenz \
+  --from-literal=jwt-secret="$(openssl rand -base64 32)" \
+  --from-literal=admin-password='<password>' \
+  --from-literal=hf-token="$HF_TOKEN" \
+  --from-literal=db-username=sardeenz \
+  --from-literal=db-password="$(openssl rand -base64 16)" \
+  --from-literal=database-url='postgresql://sardeenz:<password>@sardeenz-postgresql:5432/sardeenz'
+
+helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart --version 0.7.1 \
+  -n sardeenz --set secrets.existingSecret=sardeenz-secrets
+```
+
+The referenced Secret must contain: `jwt-secret`, `admin-password`, `client-id`,
+`client-secret`, `issuer-url`, `k8s-api-url`, `inference-api-key`, `hf-token`,
+`cluster-secret`, `db-username`, `db-password`, `database-url` (omit keys you
+don't use — all are read as optional except `database-url`).
+
+### External database
+
+```bash
+--set postgresql.enabled=false \
+--set database.url='postgresql://user:pass@db.example.com:5432/sardeenz'
+```
+
+### Kubernetes (non-OpenShift) with Ingress
+
+```bash
+--set route.enabled=false \
+--set ingress.enabled=true \
+--set ingress.className=nginx \
+--set ingress.host=sardeenz.example.com
+```
+
+## Verify
+
+```bash
+helm test sardeenz -n sardeenz   # curls /api/health/ready from an in-cluster pod
+```
+
+## Key values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Pods; also sets `CLUSTER_EXPECTED_PODS`. |
+| `image.repository` | `quay.io/rh-aiservices-bu/sardeenz` | Image repo. |
+| `image.tag` | `""` | Defaults to chart appVersion. |
+| `auth.mode` | `none` | `none` \| `simple` \| `oauth`. |
+| `secrets.create` | `true` | Template the Secret from values. |
+| `secrets.existingSecret` | `""` | Use a pre-created Secret instead. |
+| `database.url` | `""` | External DB; defaults to bundled PostgreSQL. |
+| `postgresql.enabled` | `true` | Deploy the bundled PostgreSQL. |
+| `gpu.count` | `1` | GPUs requested/limited per pod. |
+| `persistence.size` | `100Gi` | Model-cache PVC size (RWX). |
+| `route.enabled` | `true` | OpenShift Route. |
+| `ingress.enabled` | `false` | Kubernetes Ingress. |
+| `rbac.create` | `true` | RBAC (OAuth/cluster roles rendered as needed). |
+
+See [`values.yaml`](./values.yaml) for the fully documented set.
+
+## Maintainers: publishing the chart
+
+Chart version is sourced from `package.json`, keeping it in lockstep with the app.
+
+```bash
+make helm-lint            # lint
+make helm-template        # render to stdout (ARGS="--set auth.mode=oauth")
+make helm-package         # -> dist/charts/sardeenz-chart-<version>.tgz
+helm registry login quay.io
+make helm-push            # -> quay.io/rh-aiservices-bu/sardeenz-chart:<version>
+```

--- a/deploy/helm/sardeenz/templates/NOTES.txt
+++ b/deploy/helm/sardeenz/templates/NOTES.txt
@@ -1,0 +1,31 @@
+sardeenz {{ .Chart.AppVersion }} has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Pods:      {{ .Values.replicaCount }} replica(s)
+Auth mode: {{ .Values.auth.mode }}
+Database:  {{ if .Values.postgresql.enabled }}bundled PostgreSQL{{ else }}external{{ end }}
+
+Access the dashboard:
+{{- if .Values.route.enabled }}
+  OpenShift Route:
+    oc get route {{ include "sardeenz.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.spec.host}'
+{{- else if .Values.ingress.enabled }}
+  Ingress host: {{ .Values.ingress.host | default "<set ingress.host>" }}
+{{- else }}
+  Port-forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "sardeenz.fullname" . }} 3000:{{ .Values.service.port }}
+    open http://localhost:3000
+{{- end }}
+
+{{- if and (ne .Values.auth.mode "none") (not .Values.secrets.existingSecret) (not .Values.auth.jwtSecret) }}
+
+WARNING: auth.mode={{ .Values.auth.mode }} but no jwtSecret was provided.
+         Set auth.jwtSecret (openssl rand -base64 32) or use secrets.existingSecret.
+{{- end }}
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.secrets.existingSecret) (not .Values.cluster.secret) }}
+
+WARNING: replicaCount > 1 but no cluster.secret was provided.
+         Multi-pod coordination requires cluster.secret (openssl rand -hex 32).
+{{- end }}
+
+Verify the release:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/deploy/helm/sardeenz/templates/_helpers.tpl
+++ b/deploy/helm/sardeenz/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sardeenz.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "sardeenz.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version label.
+*/}}
+{{- define "sardeenz.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "sardeenz.labels" -}}
+helm.sh/chart: {{ include "sardeenz.chart" . }}
+{{ include "sardeenz.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/component: ml-platform
+app.kubernetes.io/part-of: sardeenz
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels. Includes the legacy `app` key because in-cluster peer
+discovery and the headless service select on app=<name>.
+*/}}
+{{- define "sardeenz.selectorLabels" -}}
+app: {{ include "sardeenz.name" . }}
+app.kubernetes.io/name: {{ include "sardeenz.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "sardeenz.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sardeenz.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret to reference (existing or chart-managed).
+*/}}
+{{- define "sardeenz.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- printf "%s-secrets" (include "sardeenz.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+ConfigMap name.
+*/}}
+{{- define "sardeenz.configMapName" -}}
+{{- printf "%s-config" (include "sardeenz.fullname" .) }}
+{{- end }}
+
+{{/*
+Headless service name (StatefulSet pod DNS).
+*/}}
+{{- define "sardeenz.headlessServiceName" -}}
+{{- printf "%s-headless" (include "sardeenz.fullname" .) }}
+{{- end }}
+
+{{/*
+Bundled PostgreSQL service name.
+*/}}
+{{- define "sardeenz.postgresqlName" -}}
+{{- printf "%s-postgresql" (include "sardeenz.fullname" .) }}
+{{- end }}

--- a/deploy/helm/sardeenz/templates/configmap.yaml
+++ b/deploy/helm/sardeenz/templates/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sardeenz.configMapName" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+data:
+  # Server
+  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  PORT: {{ .Values.config.port | quote }}
+  HOST: {{ .Values.config.host | quote }}
+  LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+
+  # Authentication
+  AUTH_MODE: {{ .Values.auth.mode | quote }}
+  ADMIN_USERNAME: {{ .Values.auth.adminUsername | quote }}
+  JWT_EXPIRATION_HOURS: {{ .Values.auth.jwtExpirationHours | quote }}
+  API_BASE_URL: {{ .Values.auth.apiBaseUrl | quote }}
+
+  # kvcached
+  ENABLE_KVCACHED: {{ .Values.kvcached.enabled | quote }}
+  KVCACHED_AUTOPATCH: {{ ternary "1" "0" .Values.kvcached.autopatch | quote }}
+
+  # vLLM
+  SARDEENZ_VLLM_BASE_PORT: {{ .Values.vllm.basePort | quote }}
+  SARDEENZ_VLLM_MAX_INSTANCES: {{ .Values.vllm.maxInstances | quote }}
+  SARDEENZ_VLLM_STARTUP_TIMEOUT: {{ .Values.vllm.startupTimeout | quote }}
+
+  # Optional features
+  LOCAL_MODELS_PATH: {{ .Values.config.localModelsPath | quote }}
+  DEBUG_STREAMING: {{ .Values.config.debugStreaming | quote }}
+
+  # Cluster — kept in lockstep with replicaCount.
+  CLUSTER_EXPECTED_PODS: {{ .Values.replicaCount | quote }}

--- a/deploy/helm/sardeenz/templates/ingress.yaml
+++ b/deploy/helm/sardeenz/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sardeenz.fullname" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host | quote }}
+      {{- end }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "sardeenz.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/deploy/helm/sardeenz/templates/postgresql.yaml
+++ b/deploy/helm/sardeenz/templates/postgresql.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sardeenz.postgresqlName" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ include "sardeenz.postgresqlName" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "sardeenz.postgresqlName" . }}
+        app.kubernetes.io/name: {{ include "sardeenz.postgresqlName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: database
+    spec:
+      containers:
+        - name: postgresql
+          image: {{ .Values.postgresql.image | quote }}
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: db-username } }
+            - name: POSTGRESQL_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: db-password } }
+            - name: POSTGRESQL_DATABASE
+              value: {{ .Values.postgresql.database | quote }}
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/pgsql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.database.username | quote }}]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.database.username | quote }}]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: pgdata
+          persistentVolumeClaim:
+            claimName: {{ include "sardeenz.postgresqlName" . }}-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sardeenz.postgresqlName" . }}-data
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size | quote }}
+  {{- with .Values.postgresql.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sardeenz.postgresqlName" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "sardeenz.postgresqlName" . }}
+  ports:
+    - port: 5432
+      targetPort: postgresql
+      name: postgresql
+{{- end }}

--- a/deploy/helm/sardeenz/templates/pvc.yaml
+++ b/deploy/helm/sardeenz/templates/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-model-cache
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      # Adjust to model sizes — 7B≈14GB, 13B≈26GB, 70B≈140GB.
+      storage: {{ .Values.persistence.size | quote }}
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}

--- a/deploy/helm/sardeenz/templates/rbac.yaml
+++ b/deploy/helm/sardeenz/templates/rbac.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.rbac.create }}
+{{- if eq .Values.auth.mode "oauth" }}
+# -----------------------------------------------------------------------------
+# OAuth authorization RBAC (rendered only when auth.mode=oauth)
+# -----------------------------------------------------------------------------
+# Marker role: full admin access (checked via LocalSubjectAccessReview).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-admin
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["sardeenz.rh-aiservices-bu.io"]
+    resources: ["admin"]
+    verbs: ["get"]
+---
+# Marker role: read-only access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-admin-readonly
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["sardeenz.rh-aiservices-bu.io"]
+    resources: ["admin-readonly"]
+    verbs: ["get"]
+---
+# Allows the ServiceAccount to create LocalSubjectAccessReviews for permission checks.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-auth-reviewer
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["localsubjectaccessreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-auth-reviewer
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "sardeenz.fullname" . }}-auth-reviewer
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sardeenz.serviceAccountName" . }}
+{{- end }}
+{{- if gt (int .Values.replicaCount) 1 }}
+{{- if eq .Values.auth.mode "oauth" }}
+---
+{{- end }}
+# -----------------------------------------------------------------------------
+# Cluster-coordination RBAC (rendered only when replicaCount > 1)
+# -----------------------------------------------------------------------------
+# Pod discovery (list/watch pods) and leader election (leases).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-cluster
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-cluster
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "sardeenz.fullname" . }}-cluster
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sardeenz.serviceAccountName" . }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/sardeenz/templates/route.yaml
+++ b/deploy/helm/sardeenz/templates/route.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "sardeenz.fullname" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.route.host }}
+  host: {{ . | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "sardeenz.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  {{- with .Values.route.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/deploy/helm/sardeenz/templates/secret.yaml
+++ b/deploy/helm/sardeenz/templates/secret.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+{{- /*
+Resolve the DB password once so the Secret's db-password and database-url stay
+consistent. Precedence: explicit value > existing in-cluster secret (upgrade
+stability) > freshly generated random string.
+*/}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "sardeenz.secretName" .) }}
+{{- $existingPw := "" }}
+{{- if and $existing $existing.data }}
+{{-   $existingPw = index $existing.data "db-password" | default "" }}
+{{-   if $existingPw }}{{ $existingPw = b64dec $existingPw }}{{ end }}
+{{- end }}
+{{- $dbPassword := .Values.database.password | default $existingPw | default (randAlphaNum 24) }}
+{{- $dbUrl := .Values.database.url | default (printf "postgresql://%s:%s@%s:5432/%s" .Values.database.username $dbPassword (include "sardeenz.postgresqlName" .) .Values.postgresql.database) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sardeenz.secretName" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Auth
+  jwt-secret: {{ .Values.auth.jwtSecret | quote }}
+  admin-password: {{ .Values.auth.adminPassword | quote }}
+  client-id: {{ .Values.auth.oauth.clientId | quote }}
+  client-secret: {{ .Values.auth.oauth.clientSecret | quote }}
+  issuer-url: {{ .Values.auth.oauth.issuerUrl | quote }}
+  k8s-api-url: {{ .Values.auth.oauth.k8sApiUrl | quote }}
+
+  # Inference
+  inference-api-key: {{ .Values.inferenceApiKey | quote }}
+
+  # HuggingFace
+  hf-token: {{ .Values.huggingface.token | quote }}
+
+  # Cluster
+  cluster-secret: {{ .Values.cluster.secret | quote }}
+
+  # Database
+  db-username: {{ .Values.database.username | quote }}
+  db-password: {{ $dbPassword | quote }}
+  database-url: {{ $dbUrl | quote }}
+{{- end }}

--- a/deploy/helm/sardeenz/templates/serviceaccount.yaml
+++ b/deploy/helm/sardeenz/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sardeenz.serviceAccountName" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/sardeenz/templates/services.yaml
+++ b/deploy/helm/sardeenz/templates/services.yaml
@@ -1,0 +1,37 @@
+# Headless Service — StatefulSet pod DNS (sardeenz-0.<headless>, ...).
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sardeenz.headlessServiceName" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "sardeenz.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      name: http
+---
+# ClusterIP Service — external access, load-balanced across pods.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sardeenz.fullname" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if eq .Values.service.sessionAffinity "ClientIP" }}
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.service.sessionAffinityTimeoutSeconds }}
+  {{- end }}
+  selector:
+    {{- include "sardeenz.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/sardeenz/templates/statefulset.yaml
+++ b/deploy/helm/sardeenz/templates/statefulset.yaml
@@ -1,0 +1,172 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "sardeenz.fullname" . }}
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "sardeenz.headlessServiceName" . }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "sardeenz.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sardeenz.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "sardeenz.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gpu.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gpu.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gpu.spreadAcrossNodes }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: {{ include "sardeenz.name" . }}
+                topologyKey: kubernetes.io/hostname
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: sardeenz
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.port }}
+              protocol: TCP
+          env:
+            # Server
+            - name: NODE_ENV
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: NODE_ENV } }
+            - name: PORT
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: PORT } }
+            - name: HOST
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: HOST } }
+            - name: LOG_LEVEL
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: LOG_LEVEL } }
+            # Authentication
+            - name: AUTH_MODE
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: AUTH_MODE } }
+            - name: ADMIN_USERNAME
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: ADMIN_USERNAME } }
+            - name: JWT_EXPIRATION_HOURS
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: JWT_EXPIRATION_HOURS } }
+            - name: API_BASE_URL
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: API_BASE_URL, optional: true } }
+            - name: ADMIN_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: admin-password, optional: true } }
+            - name: JWT_SECRET
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: jwt-secret, optional: true } }
+            # OAuth
+            - name: OAUTH_CLIENT_ID
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: client-id, optional: true } }
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: client-secret, optional: true } }
+            - name: OAUTH_ISSUER_URL
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: issuer-url, optional: true } }
+            - name: K8S_API_URL
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: k8s-api-url, optional: true } }
+            - name: NAMESPACE
+              valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
+            # Inference
+            - name: INFERENCE_API_KEY
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: inference-api-key, optional: true } }
+            # Cluster
+            - name: CLUSTER_SECRET
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: cluster-secret, optional: true } }
+            - name: CLUSTER_EXPECTED_PODS
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: CLUSTER_EXPECTED_PODS } }
+            # Database
+            - name: DATABASE_URL
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: database-url } }
+            # kvcached
+            - name: ENABLE_KVCACHED
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: ENABLE_KVCACHED } }
+            - name: KVCACHED_AUTOPATCH
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: KVCACHED_AUTOPATCH } }
+            # vLLM
+            - name: SARDEENZ_VLLM_BASE_PORT
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: SARDEENZ_VLLM_BASE_PORT } }
+            - name: SARDEENZ_VLLM_MAX_INSTANCES
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: SARDEENZ_VLLM_MAX_INSTANCES } }
+            - name: SARDEENZ_VLLM_STARTUP_TIMEOUT
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: SARDEENZ_VLLM_STARTUP_TIMEOUT } }
+            # Optional features
+            - name: LOCAL_MODELS_PATH
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: LOCAL_MODELS_PATH, optional: true } }
+            - name: DEBUG_STREAMING
+              valueFrom: { configMapKeyRef: { name: {{ include "sardeenz.configMapName" . }}, key: DEBUG_STREAMING, optional: true } }
+            # HuggingFace
+            - name: HF_TOKEN
+              valueFrom: { secretKeyRef: { name: {{ include "sardeenz.secretName" . }}, key: hf-token, optional: true } }
+            # Container paths
+            - name: HF_HOME
+              value: "/opt/app-root/models"
+            - name: HOME
+              value: "/opt/app-root/src"
+            - name: XDG_CACHE_HOME
+              value: "/opt/app-root/src/.cache"
+            - name: FLASHINFER_WORKSPACE_DIR
+              value: "/opt/app-root/src/.cache/flashinfer"
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu | quote }}
+              memory: {{ .Values.resources.requests.memory | quote }}
+              nvidia.com/gpu: {{ .Values.gpu.count }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu | quote }}
+              memory: {{ .Values.resources.limits.memory | quote }}
+              nvidia.com/gpu: {{ .Values.gpu.count }}
+          # Startup probe — long grace period for large model downloads.
+          startupProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            failureThreshold: 120
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /api/health/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: huggingface-cache
+              mountPath: /opt/app-root/models
+          securityContext:
+            allowPrivilegeEscalation: false
+      volumes:
+        - name: huggingface-cache
+          persistentVolumeClaim:
+            claimName: {{ include "sardeenz.fullname" . }}-model-cache

--- a/deploy/helm/sardeenz/templates/tests/test-health.yaml
+++ b/deploy/helm/sardeenz/templates/tests/test-health.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "sardeenz.fullname" . }}-test-health
+  labels:
+    {{- include "sardeenz.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: health
+      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          url="http://{{ include "sardeenz.fullname" . }}:{{ .Values.service.port }}/api/health/ready"
+          echo "Checking $url"
+          curl -sf --max-time 10 "$url"

--- a/deploy/helm/sardeenz/values.schema.json
+++ b/deploy/helm/sardeenz/values.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "sardeenz Helm values",
+  "type": "object",
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      },
+      "required": ["repository"]
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "mode": { "type": "string", "enum": ["none", "simple", "oauth"] }
+      },
+      "required": ["mode"]
+    },
+    "secrets": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "existingSecret": { "type": "string" }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadWriteOncePod"]
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "properties": { "enabled": { "type": "boolean" } }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": { "enabled": { "type": "boolean" } }
+    }
+  },
+  "required": ["replicaCount", "image", "auth"]
+}

--- a/deploy/helm/sardeenz/values.yaml
+++ b/deploy/helm/sardeenz/values.yaml
@@ -1,0 +1,222 @@
+# =============================================================================
+# sardeenz Helm chart values
+# =============================================================================
+# Every value below has a sensible default for a single-pod, no-auth install on
+# an OpenShift cluster with an NVIDIA GPU. Override per environment.
+
+# -- Number of application pods. Drives BOTH the StatefulSet replica count AND
+# the CLUSTER_EXPECTED_PODS env var, so scaling is a single-value change.
+# Set > 1 for a multi-pod cluster (requires cluster.secret / existingSecret).
+replicaCount: 1
+
+image:
+  repository: quay.io/rh-aiservices-bu/sardeenz
+  # -- Image tag. Defaults to the chart appVersion when left empty.
+  tag: ""
+  pullPolicy: Always
+
+# -- Optional image pull secrets (list of {name: <secret>}).
+imagePullSecrets: []
+
+# -- Base name used in resource names. Defaults to "sardeenz" (not the chart
+# name "sardeenz-chart") so resources render as <release>-sardeenz.
+nameOverride: "sardeenz"
+# -- Override the full release-qualified name used in resource names.
+fullnameOverride: ""
+
+# =============================================================================
+# Application server configuration -> rendered into the ConfigMap
+# =============================================================================
+config:
+  nodeEnv: production
+  port: 3000
+  host: "0.0.0.0"
+  logLevel: info
+  # -- Path to local pre-downloaded models (empty to disable).
+  localModelsPath: ""
+  # -- Verbose SSE streaming debug logs.
+  debugStreaming: false
+
+# =============================================================================
+# Authentication
+# =============================================================================
+auth:
+  # -- Admin auth mode: none | simple | oauth
+  mode: none
+  # -- Admin username (simple mode).
+  adminUsername: admin
+  jwtExpirationHours: 8
+  # -- Public base URL for OAuth callbacks, e.g. https://sardeenz.apps.example.com
+  apiBaseUrl: ""
+
+  # Sensitive auth values. These are written to the chart-managed Secret only
+  # when secrets.create=true AND secrets.existingSecret is empty.
+  # -- Admin password (simple mode).
+  adminPassword: ""
+  # -- JWT signing secret (simple/oauth). Generate: openssl rand -base64 32
+  jwtSecret: ""
+  oauth:
+    clientId: ""
+    clientSecret: ""
+    issuerUrl: ""
+    # -- Kubernetes API URL for OpenShift OAuth user-info (e.g. https://api.cluster:6443)
+    k8sApiUrl: ""
+
+# -- Inference API key for /v1/* and /api/direct/* (empty = unauthenticated).
+inferenceApiKey: ""
+
+# =============================================================================
+# Cluster coordination (multi-pod)
+# =============================================================================
+cluster:
+  # -- HMAC secret for inter-pod auth. Required when replicaCount > 1.
+  # Generate: openssl rand -hex 32. Ignored when using existingSecret.
+  secret: ""
+
+# =============================================================================
+# Secrets management
+# =============================================================================
+secrets:
+  # -- Create the chart-managed Secret from the values above.
+  create: true
+  # -- Reference a pre-created Secret instead (recommended for production).
+  # When set, no Secret is templated and these keys must exist in it:
+  # jwt-secret, admin-password, client-id, client-secret, issuer-url,
+  # k8s-api-url, inference-api-key, hf-token, cluster-secret,
+  # db-username, db-password, database-url
+  existingSecret: ""
+
+# =============================================================================
+# HuggingFace
+# =============================================================================
+huggingface:
+  # -- HF token for gated models. Ignored when using existingSecret.
+  token: ""
+
+# =============================================================================
+# Database
+# =============================================================================
+database:
+  # -- Connection string. Defaults to the bundled PostgreSQL service when empty
+  # and postgresql.enabled=true. Ignored when using existingSecret.
+  url: ""
+  username: sardeenz
+  password: ""
+
+# Bundled PostgreSQL (single-replica, for quick starts / dev).
+postgresql:
+  # -- Deploy the bundled PostgreSQL. Disable to use an external database
+  # (then set database.url or provide it via existingSecret).
+  enabled: true
+  image: registry.redhat.io/rhel9/postgresql-16:latest
+  database: sardeenz
+  persistence:
+    size: 1Gi
+    storageClassName: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# =============================================================================
+# vLLM instance management
+# =============================================================================
+vllm:
+  basePort: 12346
+  maxInstances: 10
+  # -- Model startup timeout in ms (default 30 min).
+  startupTimeout: 1800000
+
+# =============================================================================
+# kvcached GPU memory sharing
+# =============================================================================
+kvcached:
+  enabled: true
+  autopatch: true
+
+# =============================================================================
+# GPU scheduling
+# =============================================================================
+gpu:
+  # -- GPU count requested/limited per pod.
+  count: 1
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+  tolerations:
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+  # -- Spread pods across nodes (soft anti-affinity). Set false to disable.
+  spreadAcrossNodes: true
+
+# =============================================================================
+# Application resources (GPU is added automatically from gpu.count)
+# =============================================================================
+resources:
+  requests:
+    cpu: "2"
+    memory: 8Gi
+  limits:
+    cpu: "8"
+    memory: 32Gi
+
+# =============================================================================
+# Model cache persistence (shared across pods -> ReadWriteMany)
+# =============================================================================
+persistence:
+  # -- Storage for the HuggingFace model cache. Sized for several models.
+  size: 100Gi
+  accessMode: ReadWriteMany
+  storageClassName: ""
+
+# =============================================================================
+# Networking
+# =============================================================================
+service:
+  type: ClusterIP
+  port: 3000
+  # -- Sticky sessions keep a client pinned to one pod (recommended).
+  sessionAffinity: ClientIP
+  sessionAffinityTimeoutSeconds: 300
+
+# OpenShift Route (mutually exclusive with ingress in practice).
+route:
+  enabled: true
+  host: ""
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  annotations:
+    # 5 min timeout for long-running inference + SSE streaming.
+    haproxy.router.openshift.io/timeout: 300s
+    haproxy.router.openshift.io/timeout-tunnel: 300s
+
+# Vanilla Kubernetes Ingress.
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls: []
+
+# =============================================================================
+# ServiceAccount & RBAC
+# =============================================================================
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+rbac:
+  # -- Create RBAC resources. OAuth auth-reviewer role is created only when
+  # auth.mode=oauth; the cluster-coordination role only when replicaCount > 1.
+  create: true
+
+# =============================================================================
+# Probes & scheduling extras
+# =============================================================================
+terminationGracePeriodSeconds: 30
+podAnnotations: {}

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,5 +1,20 @@
 # Kubernetes/OpenShift Deployment Guide
 
+> ## ⚠️ Deprecated — use the Helm chart
+>
+> These raw Kustomize manifests are **deprecated** and will be removed in a future
+> release. The supported deployment path is now the Helm chart, which can be
+> installed directly from the registry without cloning this repo:
+>
+> ```bash
+> helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart \
+>   --version <app-version> --namespace sardeenz --create-namespace
+> ```
+>
+> See [`deploy/helm/sardeenz/README.md`](../deploy/helm/sardeenz/README.md) and
+> [`docs/deployment.md`](../docs/deployment.md). The manifests below remain only
+> as a reference for the raw Kubernetes objects.
+
 This directory contains Kubernetes manifests for deploying Sardeenz to OpenShift or vanilla Kubernetes with GPU support.
 
 ## Prerequisites

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,6 +22,7 @@ This guide covers container building and deployment to OpenShift/Kubernetes.
 - [Container Build](#container-build)
 - [Local Development](#local-development)
 - [OpenShift Deployment](#openshift-deployment)
+  - [Deploy with Helm (recommended)](#deploy-with-helm-recommended)
 - [Multi-Pod Cluster Deployment](#multi-pod-cluster-deployment)
 - [Authentication and RBAC](#authentication-and-rbac)
 - [Configuration](#configuration)
@@ -246,6 +247,36 @@ podman run -d \
 2. **Namespace** with GPU quota allocated
 3. **Image registry access** (e.g., Quay.io)
 4. **Persistent storage** - PostgreSQL for database; Model Cache PVC optional (only if downloading from HuggingFace)
+
+### Deploy with Helm (recommended)
+
+The supported way to deploy sardeenz is the Helm chart, published as an OCI
+artifact so no repo clone is required:
+
+```bash
+helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart \
+  --version <app-version> \
+  --namespace sardeenz --create-namespace
+```
+
+This installs the full stack (StatefulSet, ConfigMap/Secret, model-cache PVC,
+Services, OpenShift Route, conditional RBAC, and a bundled PostgreSQL). Common
+setups — simple/OAuth auth, multi-pod clusters, external databases, `existingSecret`
+for production, and Kubernetes Ingress instead of a Route — are documented in the
+chart README:
+
+- **[`deploy/helm/sardeenz/README.md`](../deploy/helm/sardeenz/README.md)** — install recipes and the full values reference
+- **[`deploy/helm/sardeenz/values.yaml`](../deploy/helm/sardeenz/values.yaml)** — every configurable value, documented inline
+
+Verify a release with `helm test sardeenz -n sardeenz`.
+
+> The raw Kustomize manifests under [`deployment/`](../../deployment/) are
+> **deprecated** in favor of the chart and will be removed in a future release.
+
+### Deploy with raw manifests (deprecated)
+
+The manual `Deployment`/`Service` YAML below is kept for reference only. Prefer
+the Helm chart above for new deployments.
 
 ### Deploy with GPU
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sardeenz",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sardeenz",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sardeenz",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Multi-model vLLM management platform with dynamic loading and unified inference proxy",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Release v0.8.0

Replaces the Kustomize deployment with a packageable Helm chart and bumps the version to `0.8.0` (minor bump — staying on `0.x` while experimental, despite breaking deployment/config changes).

### Helm Chart Deployment
- **Helm chart** at `deploy/helm/sardeenz/` replaces the raw Kustomize manifests as the supported deployment path, published as an OCI artifact for cloneless install:
  ```bash
  helm install sardeenz oci://quay.io/rh-aiservices-bu/sardeenz-chart \
    --version 0.8.0 --namespace sardeenz --create-namespace
  ```
- Full stack templated: StatefulSet (GPU-scheduled), ConfigMap, Secret, model-cache PVC, Services (headless + ClusterIP), OpenShift Route, conditional RBAC, optional bundled PostgreSQL.
- **Kubernetes Ingress** as an alternative to the OpenShift Route.
- `replicaCount` drives both StatefulSet replicas and `CLUSTER_EXPECTED_PODS`.
- Conditional RBAC: OAuth roles only when `auth.mode=oauth`; cluster roles only when `replicaCount > 1`.
- `secrets.existingSecret` for production; bundled DB password auto-generated and preserved across upgrades.
- `values.schema.json` install-time validation and a `helm test` health check.
- Makefile targets: `helm-lint`, `helm-template`, `helm-package`, `helm-push`, `helm-package-push` (version sourced from `package.json`).
- Fixed a latent Route bug: `targetPort` `backend` → `http`.
- Kustomize manifests under `deployment/` are **deprecated**.

### Breaking Changes
- **Deployment mechanism changed to Helm** — migrate existing Kustomize deployments to the chart.
- **vLLM env vars renamed** to the `SARDEENZ_VLLM_*` prefix (`VLLM_BASE_PORT` → `SARDEENZ_VLLM_BASE_PORT`, `VLLM_MAX_INSTANCES` → `SARDEENZ_VLLM_MAX_INSTANCES`, `VLLM_STARTUP_TIMEOUT` → `SARDEENZ_VLLM_STARTUP_TIMEOUT`). Old names are no longer read.

### Verification
- `helm lint` passes; `make helm-package` produces `sardeenz-chart-0.8.0.tgz`.
- Rendered and validated default / OAuth+multi-pod / Ingress / external-DB / existingSecret scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)